### PR TITLE
Namespacing + Clang Format + Tweaks

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,11 @@
+BasedOnStyle: LLVM
+
+AccessModifierOffset: -4
+AllowShortIfStatementsOnASingleLine: false
+BreakBeforeBraces: Attach
+ColumnLimit: 100
+IndentCaseLabels: false
+IndentWidth: 4
+NamespaceIndentation: All
+TabWidth: 4
+UseTab: Never

--- a/.clang-format
+++ b/.clang-format
@@ -5,7 +5,7 @@ AllowShortEnumsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Inline
 AllowShortIfStatementsOnASingleLine: false
 BreakBeforeBraces: Attach
-ColumnLimit: 100
+ColumnLimit: 120
 IndentCaseLabels: false
 IndentWidth: 4
 NamespaceIndentation: All

--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,8 @@
 BasedOnStyle: LLVM
 
 AccessModifierOffset: -4
+AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
 AllowShortIfStatementsOnASingleLine: false
 BreakBeforeBraces: Attach
 ColumnLimit: 100

--- a/editor/main.cpp
+++ b/editor/main.cpp
@@ -4,9 +4,9 @@ using namespace IC;
 
 int main() {
     Config config;
-    config.Name = "ICEditor";
-    config.Width = 1280;
-    config.Height = 720;
+    config.name = "ICEditor";
+    config.width = 1280;
+    config.height = 720;
 
     App::Run(&config);
 }

--- a/editor/main.cpp
+++ b/editor/main.cpp
@@ -2,8 +2,7 @@
 
 using namespace IC;
 
-int main()
-{
+int main() {
     Config config;
     config.Name = "ICEditor";
     config.Width = 1280;

--- a/include/ic.h
+++ b/include/ic.h
@@ -3,7 +3,6 @@
 #include "ic_camera.h"
 #include "ic_graphics.h"
 #include "ic_log.h"
-#include "ic_renderer.h"
 
 #if ICENGINE_EXPORTS
 __declspec(dllexport)

--- a/include/ic_app.h
+++ b/include/ic_app.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "ic_renderer.h"
+#include <ic_graphics.h>
 
 namespace IC
 {
@@ -9,6 +9,13 @@ namespace IC
     {
         // Application name.
         const char *Name = "ic";
+
+        // Which renderer to use.
+#ifdef IC_RENDERER_VULKAN
+        RendererType RendererType = RendererType::Vulkan;
+#else
+        RendererType RendererType = RendererType::None;
+#endif
 
         // Starting width, in pixels.
         // Depending on the OS DPI, the true window size may be a multiple of this.

--- a/include/ic_app.h
+++ b/include/ic_app.h
@@ -6,22 +6,22 @@ namespace IC {
     // Application Configuration
     struct Config {
         // Application name.
-        const char *Name = "ic";
+        const char *name = "ic";
 
         // Which renderer to use.
 #ifdef IC_RENDERER_VULKAN
-        RendererType RendererType = RendererType::Vulkan;
+        RendererType rendererType = RendererType::Vulkan;
 #else
-        RendererType RendererType = RendererType::None;
+        RendererType rendererType = RendererType::None;
 #endif
 
         // Starting width, in pixels.
         // Depending on the OS DPI, the true window size may be a multiple of this.
-        int Width = 1280;
+        int width = 1280;
 
         // Starting height, in pixels.
         // Depending on the OS DPI, the true window size may be a multiple of this.
-        int Height = 720;
+        int height = 720;
     };
 
     // Application

--- a/include/ic_app.h
+++ b/include/ic_app.h
@@ -2,11 +2,9 @@
 
 #include <ic_graphics.h>
 
-namespace IC
-{
+namespace IC {
     // Application Configuration
-    struct Config
-    {
+    struct Config {
         // Application name.
         const char *Name = "ic";
 
@@ -27,8 +25,7 @@ namespace IC
     };
 
     // Application
-    namespace App
-    {
+    namespace App {
         // Runs the application.
         bool Run(const Config *config);
 
@@ -40,5 +37,5 @@ namespace IC
 
         // Gets the config data used to run the application.
         const Config &GetConfig();
-    }
-}
+    } // namespace App
+} // namespace IC

--- a/include/ic_camera.h
+++ b/include/ic_camera.h
@@ -4,17 +4,17 @@
 
 namespace IC
 {
-    class ICCamera
+    class Camera
     {
-    private:
-        glm::vec3 _lookVector;
-        glm::vec3 _position;
-
     public:
-        ICCamera();
-        ~ICCamera();
+        Camera();
+        ~Camera();
 
         glm::vec3 GetLookVector() { return _lookVector; }
         glm::vec3 GetPosition() { return _position; }
+
+    private:
+        glm::vec3 _lookVector;
+        glm::vec3 _position;
     };
 }

--- a/include/ic_camera.h
+++ b/include/ic_camera.h
@@ -2,10 +2,8 @@
 
 #include <glm/glm.hpp>
 
-namespace IC
-{
-    class Camera
-    {
+namespace IC {
+    class Camera {
     public:
         Camera();
         ~Camera();
@@ -17,4 +15,4 @@ namespace IC
         glm::vec3 _lookVector;
         glm::vec3 _position;
     };
-}
+} // namespace IC

--- a/include/ic_common.h
+++ b/include/ic_common.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <functional>
+
+namespace IC
+{
+    template <class Ret, class... Args>
+    using Func = std::function<Ret(Args...)>;
+}

--- a/include/ic_common.h
+++ b/include/ic_common.h
@@ -2,8 +2,6 @@
 
 #include <functional>
 
-namespace IC
-{
-    template <class Ret, class... Args>
-    using Func = std::function<Ret(Args...)>;
+namespace IC {
+    template <class Ret, class... Args> using Func = std::function<Ret(Args...)>;
 }

--- a/include/ic_graphics.h
+++ b/include/ic_graphics.h
@@ -1,54 +1,40 @@
 #pragma once
 
 #define GLM_ENABLE_EXPERIMENTAL
-#include <glm/gtx/hash.hpp>
 #include <glm/glm.hpp>
+#include <glm/gtx/hash.hpp>
 
-#include <string>
 #include <stdexcept>
+#include <string>
 #include <vector>
 
-namespace IC
-{
-    enum class RendererType
-    {
-        None = -1,
-        Vulkan
-    };
+namespace IC {
+    enum class RendererType { None = -1, Vulkan };
 
-    enum class MaterialInputType
-    {
-        Texture,
-        Color
-    };
+    enum class MaterialInputType { Texture, Color };
 
-    struct MaterialConstants
-    {
+    struct MaterialConstants {
         glm::vec4 Color;
     };
 
-    struct Material
-    {
+    struct Material {
         std::string FragShaderData;
         std::string VertShaderData;
 
         MaterialConstants Constants;
     };
 
-    struct VertexData
-    {
+    struct VertexData {
         glm::vec3 Pos;
         glm::vec3 Color;
         glm::vec2 TexCoord;
 
-        bool operator==(const VertexData &other) const
-        {
+        bool operator==(const VertexData &other) const {
             return Pos == other.Pos && Color == other.Color && TexCoord == other.TexCoord;
         }
     };
 
-    struct Mesh
-    {
+    struct Mesh {
         std::vector<VertexData> Vertices;
         std::vector<uint32_t> Indices;
         uint32_t VertexCount;
@@ -56,18 +42,14 @@ namespace IC
 
         void LoadFromFile(std::string fileName);
     };
-}
+} // namespace IC
 
-namespace std
-{
+namespace std {
     // define hash function for vertices
-    template <>
-    struct hash<IC::VertexData>
-    {
-        size_t operator()(IC::VertexData const &vertex) const
-        {
+    template <> struct hash<IC::VertexData> {
+        size_t operator()(IC::VertexData const &vertex) const {
             return ((hash<glm::vec3>()(vertex.Pos) ^ (hash<glm::vec3>()(vertex.Color) << 1)) >> 1) ^
                    (hash<glm::vec2>()(vertex.TexCoord) << 1);
         }
     };
-}
+} // namespace std

--- a/include/ic_graphics.h
+++ b/include/ic_graphics.h
@@ -10,6 +10,12 @@
 
 namespace IC
 {
+    enum class RendererType
+    {
+        None = -1,
+        Vulkan
+    };
+
     enum class MaterialInputType
     {
         Texture,

--- a/include/ic_graphics.h
+++ b/include/ic_graphics.h
@@ -9,36 +9,42 @@
 #include <vector>
 
 namespace IC {
-    enum class RendererType { None = -1, Vulkan };
+    enum class RendererType {
+        None = -1,
+        Vulkan
+    };
 
-    enum class MaterialInputType { Texture, Color };
+    enum class MaterialInputType {
+        Texture,
+        Color
+    };
 
     struct MaterialConstants {
-        glm::vec4 Color;
+        glm::vec4 color;
     };
 
     struct Material {
-        std::string FragShaderData;
-        std::string VertShaderData;
+        std::string fragShaderData;
+        std::string vertShaderData;
 
-        MaterialConstants Constants;
+        MaterialConstants constants;
     };
 
     struct VertexData {
-        glm::vec3 Pos;
-        glm::vec3 Color;
-        glm::vec2 TexCoord;
+        glm::vec3 pos;
+        glm::vec3 color;
+        glm::vec2 texCoord;
 
         bool operator==(const VertexData &other) const {
-            return Pos == other.Pos && Color == other.Color && TexCoord == other.TexCoord;
+            return pos == other.pos && color == other.color && texCoord == other.texCoord;
         }
     };
 
     struct Mesh {
-        std::vector<VertexData> Vertices;
-        std::vector<uint32_t> Indices;
-        uint32_t VertexCount;
-        uint32_t IndexCount;
+        std::vector<VertexData> vertices;
+        std::vector<uint32_t> indices;
+        uint32_t vertexCount;
+        uint32_t indexCount;
 
         void LoadFromFile(std::string fileName);
     };
@@ -48,8 +54,8 @@ namespace std {
     // define hash function for vertices
     template <> struct hash<IC::VertexData> {
         size_t operator()(IC::VertexData const &vertex) const {
-            return ((hash<glm::vec3>()(vertex.Pos) ^ (hash<glm::vec3>()(vertex.Color) << 1)) >> 1) ^
-                   (hash<glm::vec2>()(vertex.TexCoord) << 1);
+            return ((hash<glm::vec3>()(vertex.pos) ^ (hash<glm::vec3>()(vertex.color) << 1)) >> 1) ^
+                   (hash<glm::vec2>()(vertex.texCoord) << 1);
         }
     };
 } // namespace std

--- a/include/ic_log.h
+++ b/include/ic_log.h
@@ -8,15 +8,15 @@ namespace IC
 {
     class Log
     {
-    private:
-        static std::shared_ptr<spdlog::logger> _appLogger;
-        static std::shared_ptr<spdlog::logger> _coreLogger;
-
     public:
         static void Init();
 
         inline static std::shared_ptr<spdlog::logger> &GetAppLogger() { return _appLogger; }
         inline static std::shared_ptr<spdlog::logger> &GetCoreLogger() { return _coreLogger; }
+
+    private:
+        static std::shared_ptr<spdlog::logger> _appLogger;
+        static std::shared_ptr<spdlog::logger> _coreLogger;
     };
 }
 

--- a/include/ic_log.h
+++ b/include/ic_log.h
@@ -4,10 +4,8 @@
 
 #include <spdlog/spdlog.h>
 
-namespace IC
-{
-    class Log
-    {
+namespace IC {
+    class Log {
     public:
         static void Init();
 
@@ -18,7 +16,7 @@ namespace IC
         static std::shared_ptr<spdlog::logger> _appLogger;
         static std::shared_ptr<spdlog::logger> _coreLogger;
     };
-}
+} // namespace IC
 
 // App Log Macros
 #define IC_APP_TRACE(...) ::IC::Log::GetAppLogger()->trace(__VA_ARGS__)

--- a/src/ic_app.cpp
+++ b/src/ic_app.cpp
@@ -1,33 +1,22 @@
 #include <ic_app.h>
+
 #include <ic_log.h>
+
 #include "ic_renderer.h"
-
-#ifdef IC_RENDERER_VULKAN
-#define GLFW_INCLUDE_VULKAN
-#endif
-
-#include <GLFW/glfw3.h>
-#define GLM_FORCE_RADIANS
-#define GLM_FORCE_DEPTH_ZERO_TO_ONE
-#include <glm/vec4.hpp>
-#include <glm/mat4x4.hpp>
 
 #include <iostream>
 
 using namespace IC;
 
-namespace
-{
+namespace {
     // Global App State
     Config _appConfig;
     bool _appIsRunning = false;
     bool _appIsExiting = false;
-    RendererConfig _rendererConfig{};
     Renderer *_appRendererApi;
-}
+} // namespace
 
-bool App::Run(const Config *c)
-{
+bool App::Run(const Config *c) {
     Log::Init();
 
     // Copy config over.
@@ -37,19 +26,20 @@ bool App::Run(const Config *c)
 
     glfwInit();
     glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
-    GLFWwindow *window = glfwCreateWindow(_appConfig.Width, _appConfig.Height, _appConfig.Name, nullptr, nullptr);
+    GLFWwindow *window =
+        glfwCreateWindow(_appConfig.Width, _appConfig.Height, _appConfig.Name, nullptr, nullptr);
 
-    _rendererConfig.RendererType = _appConfig.RendererType;
-    _rendererConfig.Window = window;
-    _rendererConfig.Width = _appConfig.Width;
-    _rendererConfig.Height = _appConfig.Height;
+    RendererConfig rendererConfig{};
+    rendererConfig.RendererType = _appConfig.RendererType;
+    rendererConfig.Window = window;
+    rendererConfig.Width = _appConfig.Width;
+    rendererConfig.Height = _appConfig.Height;
 
     _appIsRunning = true;
 
-    _appRendererApi = Renderer::MakeRenderer(_rendererConfig);
+    _appRendererApi = Renderer::MakeRenderer(rendererConfig);
 
-    if (_appRendererApi == nullptr)
-    {
+    if (_appRendererApi == nullptr) {
         IC_CORE_ERROR("Render module was not found.");
 
         glfwDestroyWindow(window);
@@ -68,8 +58,7 @@ bool App::Run(const Config *c)
 
     _appRendererApi->AddMesh(mesh, material);
 
-    while (!glfwWindowShouldClose(window))
-    {
+    while (!glfwWindowShouldClose(window)) {
         glfwPollEvents();
         _appRendererApi->DrawFrame();
     }
@@ -80,18 +69,11 @@ bool App::Run(const Config *c)
     return true;
 }
 
-bool App::IsRunning()
-{
-    return _appIsRunning;
-}
+bool App::IsRunning() { return _appIsRunning; }
 
-void App::Exit()
-{
+void App::Exit() {
     if (!_appIsExiting && _appIsRunning)
         _appIsExiting = true;
 }
 
-const Config &App::GetConfig()
-{
-    return _appConfig;
-}
+const Config &App::GetConfig() { return _appConfig; }

--- a/src/ic_app.cpp
+++ b/src/ic_app.cpp
@@ -26,8 +26,7 @@ bool App::Run(const Config *c) {
 
     glfwInit();
     glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
-    GLFWwindow *window =
-        glfwCreateWindow(appConfig.width, appConfig.height, appConfig.name, nullptr, nullptr);
+    GLFWwindow *window = glfwCreateWindow(appConfig.width, appConfig.height, appConfig.name, nullptr, nullptr);
 
     RendererConfig rendererConfig{};
     rendererConfig.rendererType = appConfig.rendererType;

--- a/src/ic_app.cpp
+++ b/src/ic_app.cpp
@@ -10,36 +10,36 @@ using namespace IC;
 
 namespace {
     // Global App State
-    Config _appConfig;
-    bool _appIsRunning = false;
-    bool _appIsExiting = false;
-    Renderer *_appRendererApi;
+    Config appConfig;
+    bool appIsRunning = false;
+    bool appIsExiting = false;
+    Renderer *appRendererApi;
 } // namespace
 
 bool App::Run(const Config *c) {
     Log::Init();
 
     // Copy config over.
-    _appConfig = *c;
+    appConfig = *c;
 
-    IC_CORE_INFO("Hello, {0}.", _appConfig.Name);
+    IC_CORE_INFO("Hello, {0}.", appConfig.name);
 
     glfwInit();
     glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
     GLFWwindow *window =
-        glfwCreateWindow(_appConfig.Width, _appConfig.Height, _appConfig.Name, nullptr, nullptr);
+        glfwCreateWindow(appConfig.width, appConfig.height, appConfig.name, nullptr, nullptr);
 
     RendererConfig rendererConfig{};
-    rendererConfig.RendererType = _appConfig.RendererType;
-    rendererConfig.Window = window;
-    rendererConfig.Width = _appConfig.Width;
-    rendererConfig.Height = _appConfig.Height;
+    rendererConfig.rendererType = appConfig.rendererType;
+    rendererConfig.window = window;
+    rendererConfig.width = appConfig.width;
+    rendererConfig.height = appConfig.height;
 
-    _appIsRunning = true;
+    appIsRunning = true;
 
-    _appRendererApi = Renderer::MakeRenderer(rendererConfig);
+    appRendererApi = Renderer::MakeRenderer(rendererConfig);
 
-    if (_appRendererApi == nullptr) {
+    if (appRendererApi == nullptr) {
         IC_CORE_ERROR("Render module was not found.");
 
         glfwDestroyWindow(window);
@@ -52,15 +52,15 @@ bool App::Run(const Config *c) {
     Material material{};
 
     mesh.LoadFromFile("resources/models/cube.obj");
-    material.FragShaderData = "resources/shaders/default_shader.frag.spv";
-    material.VertShaderData = "resources/shaders/default_shader.vert.spv";
-    material.Constants.Color = {1.0f, 0.0f, 0.0f, 1.0f};
+    material.fragShaderData = "resources/shaders/default_shader.frag.spv";
+    material.vertShaderData = "resources/shaders/default_shader.vert.spv";
+    material.constants.color = {1.0f, 0.0f, 0.0f, 1.0f};
 
-    _appRendererApi->AddMesh(mesh, material);
+    appRendererApi->AddMesh(mesh, material);
 
     while (!glfwWindowShouldClose(window)) {
         glfwPollEvents();
-        _appRendererApi->DrawFrame();
+        appRendererApi->DrawFrame();
     }
 
     glfwDestroyWindow(window);
@@ -69,11 +69,15 @@ bool App::Run(const Config *c) {
     return true;
 }
 
-bool App::IsRunning() { return _appIsRunning; }
-
-void App::Exit() {
-    if (!_appIsExiting && _appIsRunning)
-        _appIsExiting = true;
+bool App::IsRunning() {
+    return appIsRunning;
 }
 
-const Config &App::GetConfig() { return _appConfig; }
+void App::Exit() {
+    if (!appIsExiting && appIsRunning)
+        appIsExiting = true;
+}
+
+const Config &App::GetConfig() {
+    return appConfig;
+}

--- a/src/ic_camera.cpp
+++ b/src/ic_camera.cpp
@@ -2,7 +2,7 @@
 
 namespace IC
 {
-    ICCamera::ICCamera()
+    Camera::Camera()
     {
         _position = {2.0f, 0.0f, 2.0f};
         _lookVector = {0.0f, 1.0f, 0.0f};

--- a/src/ic_camera.cpp
+++ b/src/ic_camera.cpp
@@ -1,10 +1,8 @@
 #include <ic_camera.h>
 
-namespace IC
-{
-    Camera::Camera()
-    {
+namespace IC {
+    Camera::Camera() {
         _position = {2.0f, 0.0f, 2.0f};
         _lookVector = {0.0f, 1.0f, 0.0f};
     }
-}
+} // namespace IC

--- a/src/ic_graphics.cpp
+++ b/src/ic_graphics.cpp
@@ -23,8 +23,7 @@ namespace IC {
             for (const auto &index : shape.mesh.indices) {
                 VertexData vertex{};
 
-                vertex.pos = {attrib.vertices[3 * index.vertex_index + 0],
-                              attrib.vertices[3 * index.vertex_index + 1],
+                vertex.pos = {attrib.vertices[3 * index.vertex_index + 0], attrib.vertices[3 * index.vertex_index + 1],
                               attrib.vertices[3 * index.vertex_index + 2]};
 
                 vertex.texCoord = {attrib.texcoords[2 * index.texcoord_index + 0],

--- a/src/ic_graphics.cpp
+++ b/src/ic_graphics.cpp
@@ -1,4 +1,5 @@
 #include <ic_graphics.h>
+#include <ic_log.h>
 
 #include <tiny_obj_loader.h>
 
@@ -14,6 +15,7 @@ namespace IC
 
         if (!tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err, fileName.c_str()))
         {
+            IC_CORE_ERROR("Failed to load {0}.", fileName);
             throw std::runtime_error(warn + err);
         }
 

--- a/src/ic_graphics.cpp
+++ b/src/ic_graphics.cpp
@@ -23,26 +23,26 @@ namespace IC {
             for (const auto &index : shape.mesh.indices) {
                 VertexData vertex{};
 
-                vertex.Pos = {attrib.vertices[3 * index.vertex_index + 0],
+                vertex.pos = {attrib.vertices[3 * index.vertex_index + 0],
                               attrib.vertices[3 * index.vertex_index + 1],
                               attrib.vertices[3 * index.vertex_index + 2]};
 
-                vertex.TexCoord = {attrib.texcoords[2 * index.texcoord_index + 0],
+                vertex.texCoord = {attrib.texcoords[2 * index.texcoord_index + 0],
                                    1.0f - attrib.texcoords[2 * index.texcoord_index + 1]};
 
-                vertex.Color = {1.0f, 1.0f, 1.0f};
+                vertex.color = {1.0f, 1.0f, 1.0f};
 
                 if (uniqueVertices.count(vertex) == 0) {
-                    uniqueVertices[vertex] = static_cast<uint32_t>(Vertices.size());
-                    Vertices.push_back(vertex);
+                    uniqueVertices[vertex] = static_cast<uint32_t>(vertices.size());
+                    vertices.push_back(vertex);
                 }
 
-                Indices.push_back(uniqueVertices[vertex]);
+                indices.push_back(uniqueVertices[vertex]);
             }
         }
 
-        VertexCount = static_cast<uint32_t>(Vertices.size());
-        IndexCount = static_cast<uint32_t>(Indices.size());
-        assert(VertexCount >= 3 && "Vertex count must be at least 3");
+        vertexCount = static_cast<uint32_t>(vertices.size());
+        indexCount = static_cast<uint32_t>(indices.size());
+        assert(vertexCount >= 3 && "Vertex count must be at least 3");
     }
 } // namespace IC

--- a/src/ic_graphics.cpp
+++ b/src/ic_graphics.cpp
@@ -1,30 +1,26 @@
 #include <ic_graphics.h>
+
 #include <ic_log.h>
 
 #include <tiny_obj_loader.h>
 
-namespace IC
-{
-    void Mesh::LoadFromFile(std::string fileName)
-    {
+namespace IC {
+    void Mesh::LoadFromFile(std::string fileName) {
 
         tinyobj::attrib_t attrib;
         std::vector<tinyobj::shape_t> shapes;
         std::vector<tinyobj::material_t> materials;
         std::string warn, err;
 
-        if (!tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err, fileName.c_str()))
-        {
+        if (!tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err, fileName.c_str())) {
             IC_CORE_ERROR("Failed to load {0}.", fileName);
             throw std::runtime_error(warn + err);
         }
 
         std::unordered_map<VertexData, uint32_t> uniqueVertices{};
 
-        for (const auto &shape : shapes)
-        {
-            for (const auto &index : shape.mesh.indices)
-            {
+        for (const auto &shape : shapes) {
+            for (const auto &index : shape.mesh.indices) {
                 VertexData vertex{};
 
                 vertex.Pos = {attrib.vertices[3 * index.vertex_index + 0],
@@ -36,8 +32,7 @@ namespace IC
 
                 vertex.Color = {1.0f, 1.0f, 1.0f};
 
-                if (uniqueVertices.count(vertex) == 0)
-                {
+                if (uniqueVertices.count(vertex) == 0) {
                     uniqueVertices[vertex] = static_cast<uint32_t>(Vertices.size());
                     Vertices.push_back(vertex);
                 }
@@ -50,4 +45,4 @@ namespace IC
         IndexCount = static_cast<uint32_t>(Indices.size());
         assert(VertexCount >= 3 && "Vertex count must be at least 3");
     }
-}
+} // namespace IC

--- a/src/ic_log.cpp
+++ b/src/ic_log.cpp
@@ -1,13 +1,12 @@
 #include <ic_log.h>
+
 #include <spdlog/sinks/stdout_color_sinks.h>
 
-namespace IC
-{
+namespace IC {
     std::shared_ptr<spdlog::logger> Log::_appLogger;
     std::shared_ptr<spdlog::logger> Log::_coreLogger;
 
-    void Log::Init()
-    {
+    void Log::Init() {
         spdlog::set_pattern("%^[%T] %n: %v%$");
 
         _coreLogger = spdlog::stdout_color_mt("IC");
@@ -16,4 +15,4 @@ namespace IC
         _appLogger = spdlog::stdout_color_mt("ICApp");
         _appLogger->set_level(spdlog::level::trace);
     }
-}
+} // namespace IC

--- a/src/ic_renderer.h
+++ b/src/ic_renderer.h
@@ -8,22 +8,22 @@
 
 namespace IC {
     struct RendererConfig {
-        RendererType RendererType;
-        GLFWwindow *Window;
-        int Width;
-        int Height;
+        RendererType rendererType;
+        GLFWwindow *window;
+        int width;
+        int height;
     };
 
     class Renderer {
     public:
-        Renderer(RendererConfig config) { Window = config.Window; };
+        Renderer(RendererConfig config) { window = config.window; };
         ~Renderer() = default;
 
         virtual void DrawFrame() = 0;
         virtual void AddMesh(Mesh &meshData, Material &materialData) = 0;
 
     protected:
-        GLFWwindow *Window;
+        GLFWwindow *window;
 
     private:
 #ifdef IC_RENDERER_VULKAN
@@ -34,7 +34,7 @@ namespace IC {
 
     public:
         static Renderer *MakeRenderer(RendererConfig &rendererConfig) {
-            switch (rendererConfig.RendererType) {
+            switch (rendererConfig.rendererType) {
             case RendererType::Vulkan:
                 return MakeVulkan(rendererConfig);
             default:

--- a/src/ic_renderer.h
+++ b/src/ic_renderer.h
@@ -1,22 +1,20 @@
 #pragma once
 
-#include <GLFW/glfw3.h>
 #include <ic_graphics.h>
+
+#include <GLFW/glfw3.h>
 
 #include <vector>
 
-namespace IC
-{
-    struct RendererConfig
-    {
+namespace IC {
+    struct RendererConfig {
         RendererType RendererType;
         GLFWwindow *Window;
         int Width;
         int Height;
     };
 
-    class Renderer
-    {
+    class Renderer {
     public:
         Renderer(RendererConfig config) { Window = config.Window; };
         ~Renderer() = default;
@@ -31,17 +29,12 @@ namespace IC
 #ifdef IC_RENDERER_VULKAN
         static Renderer *MakeVulkan(RendererConfig &rendererConfig);
 #else
-        static Renderer *MakeVulkan(RendererConfig &rendererConfig)
-        {
-            return nullptr;
-        }
+        static Renderer *MakeVulkan(RendererConfig &rendererConfig) { return nullptr; }
 #endif
 
     public:
-        static Renderer *MakeRenderer(RendererConfig &rendererConfig)
-        {
-            switch (rendererConfig.RendererType)
-            {
+        static Renderer *MakeRenderer(RendererConfig &rendererConfig) {
+            switch (rendererConfig.RendererType) {
             case RendererType::Vulkan:
                 return MakeVulkan(rendererConfig);
             default:
@@ -49,4 +42,4 @@ namespace IC
             }
         }
     };
-}
+} // namespace IC

--- a/src/ic_renderer.h
+++ b/src/ic_renderer.h
@@ -29,7 +29,9 @@ namespace IC {
 #ifdef IC_RENDERER_VULKAN
         static Renderer *MakeVulkan(RendererConfig &rendererConfig);
 #else
-        static Renderer *MakeVulkan(RendererConfig &rendererConfig) { return nullptr; }
+        static Renderer *MakeVulkan(RendererConfig &rendererConfig) {
+            return nullptr;
+        }
 #endif
 
     public:

--- a/src/ic_renderer.h
+++ b/src/ic_renderer.h
@@ -1,18 +1,12 @@
 #pragma once
 
 #include <GLFW/glfw3.h>
-#include "ic_graphics.h"
+#include <ic_graphics.h>
 
 #include <vector>
 
-namespace IC::Renderer
+namespace IC
 {
-    enum class RendererType
-    {
-        None = -1,
-        Vulkan
-    };
-
     struct RendererConfig
     {
         RendererType RendererType;
@@ -23,11 +17,6 @@ namespace IC::Renderer
 
     class Renderer
     {
-    protected:
-        GLFWwindow *Window;
-
-        static Renderer *MakeVulkan(RendererConfig &rendererConfig);
-
     public:
         Renderer(RendererConfig config) { Window = config.Window; };
         ~Renderer() = default;
@@ -35,6 +24,20 @@ namespace IC::Renderer
         virtual void DrawFrame() = 0;
         virtual void AddMesh(Mesh &meshData, Material &materialData) = 0;
 
+    protected:
+        GLFWwindow *Window;
+
+    private:
+#ifdef IC_RENDERER_VULKAN
+        static Renderer *MakeVulkan(RendererConfig &rendererConfig);
+#else
+        static Renderer *MakeVulkan(RendererConfig &rendererConfig)
+        {
+            return nullptr;
+        }
+#endif
+
+    public:
         static Renderer *MakeRenderer(RendererConfig &rendererConfig)
         {
             switch (rendererConfig.RendererType)

--- a/src/vulkan/descriptors.cpp
+++ b/src/vulkan/descriptors.cpp
@@ -1,7 +1,7 @@
 #include "descriptors.h"
 #include "swap_chain.h"
 
-namespace IC::Renderer
+namespace IC
 {
     void DescriptorLayoutBuilder::AddBinding(uint32_t binding, VkDescriptorType type)
     {

--- a/src/vulkan/descriptors.cpp
+++ b/src/vulkan/descriptors.cpp
@@ -16,14 +16,12 @@ namespace IC {
         bindings.clear();
     }
 
-    VkDescriptorSetLayout DescriptorLayoutBuilder::Build(VkDevice device,
-                                                         VkShaderStageFlags shaderStages) {
+    VkDescriptorSetLayout DescriptorLayoutBuilder::Build(VkDevice device, VkShaderStageFlags shaderStages) {
         for (VkDescriptorSetLayoutBinding &binding : bindings) {
             binding.stageFlags |= shaderStages;
         }
 
-        VkDescriptorSetLayoutCreateInfo info = {
-            .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO};
+        VkDescriptorSetLayoutCreateInfo info = {.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO};
         info.pNext = nullptr;
 
         info.pBindings = bindings.data();
@@ -36,8 +34,8 @@ namespace IC {
         return set;
     }
 
-    void DescriptorWriter::WriteImage(int binding, VkImageView image, VkSampler sampler,
-                                      VkImageLayout layout, VkDescriptorType type) {
+    void DescriptorWriter::WriteImage(int binding, VkImageView image, VkSampler sampler, VkImageLayout layout,
+                                      VkDescriptorType type) {
         VkDescriptorImageInfo info = imageInfos.emplace_back(
             VkDescriptorImageInfo{.sampler = sampler, .imageView = image, .imageLayout = layout});
 
@@ -54,8 +52,8 @@ namespace IC {
 
     void DescriptorWriter::WriteBuffer(int binding, VkBuffer buffer, size_t size, size_t offset,
                                        VkDescriptorType type) {
-        VkDescriptorBufferInfo &info = bufferInfos.emplace_back(
-            VkDescriptorBufferInfo{.buffer = buffer, .offset = offset, .range = size});
+        VkDescriptorBufferInfo &info =
+            bufferInfos.emplace_back(VkDescriptorBufferInfo{.buffer = buffer, .offset = offset, .range = size});
 
         VkWriteDescriptorSet write = {.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET};
 
@@ -82,8 +80,7 @@ namespace IC {
         vkUpdateDescriptorSets(device, (uint32_t)writes.size(), writes.data(), 0, nullptr);
     }
 
-    void DescriptorAllocator::CreateDescriptorPool(VkDevice device,
-                                                   std::vector<VkDescriptorPoolSize> poolSizes,
+    void DescriptorAllocator::CreateDescriptorPool(VkDevice device, std::vector<VkDescriptorPoolSize> poolSizes,
                                                    uint32_t maxSets) {
         VkDescriptorPoolCreateInfo poolInfo{};
         poolInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;

--- a/src/vulkan/descriptors.cpp
+++ b/src/vulkan/descriptors.cpp
@@ -1,10 +1,9 @@
 #include "descriptors.h"
+
 #include "swap_chain.h"
 
-namespace IC
-{
-    void DescriptorLayoutBuilder::AddBinding(uint32_t binding, VkDescriptorType type)
-    {
+namespace IC {
+    void DescriptorLayoutBuilder::AddBinding(uint32_t binding, VkDescriptorType type) {
         VkDescriptorSetLayoutBinding newBinding{};
         newBinding.binding = binding;
         newBinding.descriptorCount = 1;
@@ -13,19 +12,16 @@ namespace IC
         bindings.push_back(newBinding);
     }
 
-    void DescriptorLayoutBuilder::Clear()
-    {
-        bindings.clear();
-    }
+    void DescriptorLayoutBuilder::Clear() { bindings.clear(); }
 
-    VkDescriptorSetLayout DescriptorLayoutBuilder::Build(VkDevice device, VkShaderStageFlags shaderStages)
-    {
-        for (VkDescriptorSetLayoutBinding &binding : bindings)
-        {
+    VkDescriptorSetLayout DescriptorLayoutBuilder::Build(VkDevice device,
+                                                         VkShaderStageFlags shaderStages) {
+        for (VkDescriptorSetLayoutBinding &binding : bindings) {
             binding.stageFlags |= shaderStages;
         }
 
-        VkDescriptorSetLayoutCreateInfo info = {.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO};
+        VkDescriptorSetLayoutCreateInfo info = {
+            .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO};
         info.pNext = nullptr;
 
         info.pBindings = bindings.data();
@@ -38,12 +34,10 @@ namespace IC
         return set;
     }
 
-    void DescriptorWriter::WriteImage(int binding, VkImageView image, VkSampler sampler, VkImageLayout layout, VkDescriptorType type)
-    {
-        VkDescriptorImageInfo info = imageInfos.emplace_back(VkDescriptorImageInfo{
-            .sampler = sampler,
-            .imageView = image,
-            .imageLayout = layout});
+    void DescriptorWriter::WriteImage(int binding, VkImageView image, VkSampler sampler,
+                                      VkImageLayout layout, VkDescriptorType type) {
+        VkDescriptorImageInfo info = imageInfos.emplace_back(
+            VkDescriptorImageInfo{.sampler = sampler, .imageView = image, .imageLayout = layout});
 
         VkWriteDescriptorSet write = {.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET};
 
@@ -56,12 +50,10 @@ namespace IC
         writes.push_back(write);
     }
 
-    void DescriptorWriter::WriteBuffer(int binding, VkBuffer buffer, size_t size, size_t offset, VkDescriptorType type)
-    {
-        VkDescriptorBufferInfo &info = bufferInfos.emplace_back(VkDescriptorBufferInfo{
-            .buffer = buffer,
-            .offset = offset,
-            .range = size});
+    void DescriptorWriter::WriteBuffer(int binding, VkBuffer buffer, size_t size, size_t offset,
+                                       VkDescriptorType type) {
+        VkDescriptorBufferInfo &info = bufferInfos.emplace_back(
+            VkDescriptorBufferInfo{.buffer = buffer, .offset = offset, .range = size});
 
         VkWriteDescriptorSet write = {.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET};
 
@@ -74,25 +66,23 @@ namespace IC
         writes.push_back(write);
     }
 
-    void DescriptorWriter::Clear()
-    {
+    void DescriptorWriter::Clear() {
         imageInfos.clear();
         writes.clear();
         bufferInfos.clear();
     }
 
-    void DescriptorWriter::UpdateSet(VkDevice device, VkDescriptorSet set)
-    {
-        for (VkWriteDescriptorSet &write : writes)
-        {
+    void DescriptorWriter::UpdateSet(VkDevice device, VkDescriptorSet set) {
+        for (VkWriteDescriptorSet &write : writes) {
             write.dstSet = set;
         }
 
         vkUpdateDescriptorSets(device, (uint32_t)writes.size(), writes.data(), 0, nullptr);
     }
 
-    void DescriptorAllocator::CreateDescriptorPool(VkDevice device, std::vector<VkDescriptorPoolSize> poolSizes, uint32_t maxSets)
-    {
+    void DescriptorAllocator::CreateDescriptorPool(VkDevice device,
+                                                   std::vector<VkDescriptorPoolSize> poolSizes,
+                                                   uint32_t maxSets) {
         VkDescriptorPoolCreateInfo poolInfo{};
         poolInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
         poolInfo.poolSizeCount = static_cast<uint32_t>(poolSizes.size());
@@ -102,8 +92,8 @@ namespace IC
         VK_CHECK(vkCreateDescriptorPool(device, &poolInfo, nullptr, &_pool));
     }
 
-    void DescriptorAllocator::AllocateDescriptorSets(VkDevice device, VkDescriptorSetLayout layout, std::vector<VkDescriptorSet> &descriptorSets)
-    {
+    void DescriptorAllocator::AllocateDescriptorSets(VkDevice device, VkDescriptorSetLayout layout,
+                                                     std::vector<VkDescriptorSet> &descriptorSets) {
         std::vector<VkDescriptorSetLayout> layouts(SwapChain::MAX_FRAMES_IN_FLIGHT, layout);
         VkDescriptorSetAllocateInfo allocInfo{};
         allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
@@ -115,8 +105,7 @@ namespace IC
         VK_CHECK(vkAllocateDescriptorSets(device, &allocInfo, descriptorSets.data()));
     }
 
-    void DescriptorAllocator::DestroyDescriptorPool(VkDevice device)
-    {
+    void DescriptorAllocator::DestroyDescriptorPool(VkDevice device) {
         vkDestroyDescriptorPool(device, _pool, nullptr);
     }
-}
+} // namespace IC

--- a/src/vulkan/descriptors.cpp
+++ b/src/vulkan/descriptors.cpp
@@ -12,7 +12,9 @@ namespace IC {
         bindings.push_back(newBinding);
     }
 
-    void DescriptorLayoutBuilder::Clear() { bindings.clear(); }
+    void DescriptorLayoutBuilder::Clear() {
+        bindings.clear();
+    }
 
     VkDescriptorSetLayout DescriptorLayoutBuilder::Build(VkDevice device,
                                                          VkShaderStageFlags shaderStages) {

--- a/src/vulkan/descriptors.h
+++ b/src/vulkan/descriptors.h
@@ -20,10 +20,8 @@ namespace IC {
         std::deque<VkDescriptorBufferInfo> bufferInfos;
         std::vector<VkWriteDescriptorSet> writes;
 
-        void WriteImage(int binding, VkImageView image, VkSampler sampler, VkImageLayout layout,
-                        VkDescriptorType type);
-        void WriteBuffer(int binding, VkBuffer buffer, size_t size, size_t offset,
-                         VkDescriptorType type);
+        void WriteImage(int binding, VkImageView image, VkSampler sampler, VkImageLayout layout, VkDescriptorType type);
+        void WriteBuffer(int binding, VkBuffer buffer, size_t size, size_t offset, VkDescriptorType type);
 
         void Clear();
         void UpdateSet(VkDevice device, VkDescriptorSet set);
@@ -32,8 +30,7 @@ namespace IC {
     // Descriptor Pool Allocator
     struct DescriptorAllocator {
     public:
-        void CreateDescriptorPool(VkDevice device, std::vector<VkDescriptorPoolSize> poolSizes,
-                                  uint32_t maxSets);
+        void CreateDescriptorPool(VkDevice device, std::vector<VkDescriptorPoolSize> poolSizes, uint32_t maxSets);
         void AllocateDescriptorSets(VkDevice device, VkDescriptorSetLayout layout,
                                     std::vector<VkDescriptorSet> &descriptorSets);
         void DestroyDescriptorPool(VkDevice device);

--- a/src/vulkan/descriptors.h
+++ b/src/vulkan/descriptors.h
@@ -5,7 +5,7 @@
 #include <vector>
 #include <deque>
 
-namespace IC::Renderer
+namespace IC
 {
     // Builds Descriptor Set Layouts
     struct DescriptorLayoutBuilder

--- a/src/vulkan/descriptors.h
+++ b/src/vulkan/descriptors.h
@@ -2,14 +2,12 @@
 
 #include "vulkan_types.h"
 
-#include <vector>
 #include <deque>
+#include <vector>
 
-namespace IC
-{
+namespace IC {
     // Builds Descriptor Set Layouts
-    struct DescriptorLayoutBuilder
-    {
+    struct DescriptorLayoutBuilder {
         std::vector<VkDescriptorSetLayoutBinding> bindings;
 
         void AddBinding(uint32_t binding, VkDescriptorType type);
@@ -17,28 +15,30 @@ namespace IC
         VkDescriptorSetLayout Build(VkDevice device, VkShaderStageFlags shaderStages);
     };
 
-    struct DescriptorWriter
-    {
+    struct DescriptorWriter {
         std::deque<VkDescriptorImageInfo> imageInfos;
         std::deque<VkDescriptorBufferInfo> bufferInfos;
         std::vector<VkWriteDescriptorSet> writes;
 
-        void WriteImage(int binding, VkImageView image, VkSampler sampler, VkImageLayout layout, VkDescriptorType type);
-        void WriteBuffer(int binding, VkBuffer buffer, size_t size, size_t offset, VkDescriptorType type);
+        void WriteImage(int binding, VkImageView image, VkSampler sampler, VkImageLayout layout,
+                        VkDescriptorType type);
+        void WriteBuffer(int binding, VkBuffer buffer, size_t size, size_t offset,
+                         VkDescriptorType type);
 
         void Clear();
         void UpdateSet(VkDevice device, VkDescriptorSet set);
     };
 
     // Descriptor Pool Allocator
-    struct DescriptorAllocator
-    {
+    struct DescriptorAllocator {
     public:
-        void CreateDescriptorPool(VkDevice device, std::vector<VkDescriptorPoolSize> poolSizes, uint32_t maxSets);
-        void AllocateDescriptorSets(VkDevice device, VkDescriptorSetLayout layout, std::vector<VkDescriptorSet> &descriptorSets);
+        void CreateDescriptorPool(VkDevice device, std::vector<VkDescriptorPoolSize> poolSizes,
+                                  uint32_t maxSets);
+        void AllocateDescriptorSets(VkDevice device, VkDescriptorSetLayout layout,
+                                    std::vector<VkDescriptorSet> &descriptorSets);
         void DestroyDescriptorPool(VkDevice device);
 
     private:
         VkDescriptorPool _pool;
     };
-}
+} // namespace IC

--- a/src/vulkan/pipelines.cpp
+++ b/src/vulkan/pipelines.cpp
@@ -1,3 +1,5 @@
+#include <ic_log.h>
+
 #include "pipelines.h"
 
 #include "swap_chain.h"
@@ -29,7 +31,8 @@ namespace IC
 
         if (!file.is_open())
         {
-            throw std::runtime_error("failed to open file: " + filePath);
+            IC_CORE_ERROR("Failed to open file {0}.", filePath);
+            throw std::runtime_error("Failed to open file " + filePath + ".");
             return VK_NULL_HANDLE;
         }
 
@@ -50,7 +53,8 @@ namespace IC
 
         if (vkCreateShaderModule(device, &createInfo, nullptr, &shaderModule) != VK_SUCCESS)
         {
-            throw std::runtime_error("Failed to create shader module");
+            IC_CORE_ERROR("Failed to create shader module.");
+            throw std::runtime_error("Failed to create shader module.");
             return VK_NULL_HANDLE;
         }
 
@@ -111,7 +115,8 @@ namespace IC
         if (vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr,
                                       &newPipeline) != VK_SUCCESS)
         {
-            throw std::runtime_error("failed to create graphics pipeline");
+            IC_CORE_ERROR("Failed to create graphics pipeline.");
+            throw std::runtime_error("Failed to create graphics pipeline.");
             return VK_NULL_HANDLE;
         }
 
@@ -130,7 +135,8 @@ namespace IC
         if (vkCreateComputePipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &newPipeline) !=
             VK_SUCCESS)
         {
-            throw std::runtime_error("failed to create compute pipeline");
+            IC_CORE_ERROR("Failed to create compute pipeline.");
+            throw std::runtime_error("Failed to create compute pipeline.");
         }
         return newPipeline;
     }
@@ -251,7 +257,7 @@ namespace IC
                 return pipeline;
             }
         }
-        return Init::CreateOpaquePipeline(device, swapChain, materialData);
+        return CreateOpaquePipeline(device, swapChain, materialData);
     }
 
     bool PipelineManager::IsPipelineSuitable(Pipeline &pipeline, Material &materialData)

--- a/src/vulkan/pipelines.cpp
+++ b/src/vulkan/pipelines.cpp
@@ -1,20 +1,17 @@
-#include <ic_log.h>
-
 #include "pipelines.h"
+
+#include <ic_log.h>
 
 #include "swap_chain.h"
 #include "vulkan_initializers.h"
 #include "vulkan_types.h"
 
-// std
 #include <fstream>
 #include <iostream>
 #include <stdexcept>
 
-namespace IC
-{
-    void PipelineBuilder::clear()
-    {
+namespace IC {
+    void PipelineBuilder::clear() {
         inputAssembly = {.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO};
         rasterizer = {.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO};
         colorBlendAttachment = {};
@@ -25,15 +22,13 @@ namespace IC
         shaderStages.clear();
     }
 
-    VkShaderModule PipelineBuilder::CreateShaderModule(VkDevice device, const std::string &filePath)
-    {
+    VkShaderModule PipelineBuilder::CreateShaderModule(VkDevice device,
+                                                       const std::string &filePath) {
         std::ifstream file{filePath, std::ios::ate | std::ios::binary};
 
-        if (!file.is_open())
-        {
+        if (!file.is_open()) {
             IC_CORE_ERROR("Failed to open file {0}.", filePath);
             throw std::runtime_error("Failed to open file " + filePath + ".");
-            return VK_NULL_HANDLE;
         }
 
         size_t fileSize = static_cast<size_t>(file.tellg());
@@ -51,18 +46,15 @@ namespace IC
 
         VkShaderModule shaderModule;
 
-        if (vkCreateShaderModule(device, &createInfo, nullptr, &shaderModule) != VK_SUCCESS)
-        {
+        if (vkCreateShaderModule(device, &createInfo, nullptr, &shaderModule) != VK_SUCCESS) {
             IC_CORE_ERROR("Failed to create shader module.");
             throw std::runtime_error("Failed to create shader module.");
-            return VK_NULL_HANDLE;
         }
 
         return shaderModule;
     }
 
-    VkPipeline PipelineBuilder::BuildPipeline(VkDevice device)
-    {
+    VkPipeline PipelineBuilder::BuildPipeline(VkDevice device) {
         VkPipelineViewportStateCreateInfo viewportState = {};
         viewportState.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
         viewportState.pNext = nullptr;
@@ -113,66 +105,56 @@ namespace IC
 
         VkPipeline newPipeline;
         if (vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr,
-                                      &newPipeline) != VK_SUCCESS)
-        {
+                                      &newPipeline) != VK_SUCCESS) {
             IC_CORE_ERROR("Failed to create graphics pipeline.");
             throw std::runtime_error("Failed to create graphics pipeline.");
-            return VK_NULL_HANDLE;
         }
 
         return newPipeline;
     }
 
-    VkPipeline PipelineBuilder::BuildComputePipeline(VkDevice device)
-    {
-        VkComputePipelineCreateInfo pipelineInfo{.sType =
-                                                     VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO};
+    VkPipeline PipelineBuilder::BuildComputePipeline(VkDevice device) {
+        VkComputePipelineCreateInfo pipelineInfo{
+            .sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO};
         pipelineInfo.pNext = nullptr;
         pipelineInfo.stage = shaderStages[0];
         pipelineInfo.layout = pipelineLayout;
 
         VkPipeline newPipeline;
-        if (vkCreateComputePipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &newPipeline) !=
-            VK_SUCCESS)
-        {
+        if (vkCreateComputePipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr,
+                                     &newPipeline) != VK_SUCCESS) {
             IC_CORE_ERROR("Failed to create compute pipeline.");
             throw std::runtime_error("Failed to create compute pipeline.");
         }
         return newPipeline;
     }
 
-    void PipelineBuilder::SetShaders(VkShaderModule vertexShader, VkShaderModule fragmentShader)
-    {
+    void PipelineBuilder::SetShaders(VkShaderModule vertexShader, VkShaderModule fragmentShader) {
         shaderStages.clear();
         shaderStages.push_back(ShaderStageCreateInfo(VK_SHADER_STAGE_VERTEX_BIT, vertexShader));
         shaderStages.push_back(ShaderStageCreateInfo(VK_SHADER_STAGE_FRAGMENT_BIT, fragmentShader));
     }
 
-    void PipelineBuilder::SetComputeShader(VkShaderModule computeShader)
-    {
+    void PipelineBuilder::SetComputeShader(VkShaderModule computeShader) {
         shaderStages.push_back(ShaderStageCreateInfo(VK_SHADER_STAGE_COMPUTE_BIT, computeShader));
     }
 
-    void PipelineBuilder::SetInputTopology(VkPrimitiveTopology topology)
-    {
+    void PipelineBuilder::SetInputTopology(VkPrimitiveTopology topology) {
         inputAssembly.topology = topology;
         inputAssembly.primitiveRestartEnable = VK_FALSE;
     }
 
-    void PipelineBuilder::SetPolygonMode(VkPolygonMode mode)
-    {
+    void PipelineBuilder::SetPolygonMode(VkPolygonMode mode) {
         rasterizer.polygonMode = mode;
         rasterizer.lineWidth = 1.f;
     }
 
-    void PipelineBuilder::SetCullMode(VkCullModeFlags cullMode, VkFrontFace frontFace)
-    {
+    void PipelineBuilder::SetCullMode(VkCullModeFlags cullMode, VkFrontFace frontFace) {
         rasterizer.cullMode = cullMode;
         rasterizer.frontFace = frontFace;
     }
 
-    void PipelineBuilder::SetMultisamplingNone()
-    {
+    void PipelineBuilder::SetMultisamplingNone() {
         multisampling.sampleShadingEnable = VK_FALSE;
         multisampling.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
         multisampling.minSampleShading = 1.0f;
@@ -181,15 +163,13 @@ namespace IC
         multisampling.alphaToOneEnable = VK_FALSE;
     }
 
-    void PipelineBuilder::DisableBlending()
-    {
+    void PipelineBuilder::DisableBlending() {
         colorBlendAttachment.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
                                               VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
         colorBlendAttachment.blendEnable = VK_FALSE;
     }
 
-    void PipelineBuilder::EnableBlending()
-    {
+    void PipelineBuilder::EnableBlending() {
         colorBlendAttachment.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
                                               VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
         colorBlendAttachment.blendEnable = VK_TRUE;
@@ -201,17 +181,17 @@ namespace IC
         colorBlendAttachment.dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
     }
 
-    void PipelineBuilder::SetColorAttachmentFormat(VkFormat format)
-    {
+    void PipelineBuilder::SetColorAttachmentFormat(VkFormat format) {
         colorAttachmentformat = format;
         renderInfo.colorAttachmentCount = 1;
         renderInfo.pColorAttachmentFormats = &colorAttachmentformat;
     }
 
-    void PipelineBuilder::SetDepthFormat(VkFormat format) { renderInfo.depthAttachmentFormat = format; }
+    void PipelineBuilder::SetDepthFormat(VkFormat format) {
+        renderInfo.depthAttachmentFormat = format;
+    }
 
-    void PipelineBuilder::DisableDepthTest()
-    {
+    void PipelineBuilder::DisableDepthTest() {
         depthStencil.depthTestEnable = VK_FALSE;
         depthStencil.depthWriteEnable = VK_FALSE;
         depthStencil.depthCompareOp = VK_COMPARE_OP_NEVER;
@@ -223,8 +203,7 @@ namespace IC
         depthStencil.maxDepthBounds = 1.f;
     }
 
-    void PipelineBuilder::EnableDepthTest()
-    {
+    void PipelineBuilder::EnableDepthTest() {
         depthStencil.depthTestEnable = VK_TRUE;
         depthStencil.depthWriteEnable = VK_TRUE;
         depthStencil.depthCompareOp = VK_COMPARE_OP_LESS;
@@ -236,9 +215,8 @@ namespace IC
         depthStencil.maxDepthBounds = 1.f;
     }
 
-    VkPipelineShaderStageCreateInfo PipelineBuilder::ShaderStageCreateInfo(VkShaderStageFlagBits flags,
-                                                                           VkShaderModule module)
-    {
+    VkPipelineShaderStageCreateInfo
+    PipelineBuilder::ShaderStageCreateInfo(VkShaderStageFlagBits flags, VkShaderModule module) {
         VkPipelineShaderStageCreateInfo createInfo{
             .sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO};
         createInfo.stage = flags;
@@ -248,21 +226,19 @@ namespace IC
     }
 
     // pipeline manager
-    std::shared_ptr<Pipeline> PipelineManager::FindOrCreateSuitablePipeline(VkDevice device, SwapChain &swapChain, Material &materialData)
-    {
-        for (auto pipeline : _createdPipelines)
-        {
-            if (IsPipelineSuitable(*pipeline, materialData))
-            {
+    std::shared_ptr<Pipeline>
+    PipelineManager::FindOrCreateSuitablePipeline(VkDevice device, SwapChain &swapChain,
+                                                  Material &materialData) {
+        for (auto pipeline : _createdPipelines) {
+            if (IsPipelineSuitable(*pipeline, materialData)) {
                 return pipeline;
             }
         }
         return CreateOpaquePipeline(device, swapChain, materialData);
     }
 
-    bool PipelineManager::IsPipelineSuitable(Pipeline &pipeline, Material &materialData)
-    {
+    bool PipelineManager::IsPipelineSuitable(Pipeline &pipeline, Material &materialData) {
         // todo: code this
         return true;
     }
-}
+} // namespace IC

--- a/src/vulkan/pipelines.cpp
+++ b/src/vulkan/pipelines.cpp
@@ -22,8 +22,7 @@ namespace IC {
         shaderStages.clear();
     }
 
-    VkShaderModule PipelineBuilder::CreateShaderModule(VkDevice device,
-                                                       const std::string &filePath) {
+    VkShaderModule PipelineBuilder::CreateShaderModule(VkDevice device, const std::string &filePath) {
         std::ifstream file{filePath, std::ios::ate | std::ios::binary};
 
         if (!file.is_open()) {
@@ -73,14 +72,12 @@ namespace IC {
         auto attributeDescriptions = GetVertexAttributeDescriptions();
         VkPipelineVertexInputStateCreateInfo vertexInputInfo{};
         vertexInputInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
-        vertexInputInfo.vertexAttributeDescriptionCount =
-            static_cast<uint32_t>(attributeDescriptions.size());
+        vertexInputInfo.vertexAttributeDescriptionCount = static_cast<uint32_t>(attributeDescriptions.size());
         vertexInputInfo.vertexBindingDescriptionCount = 1;
         vertexInputInfo.pVertexAttributeDescriptions = attributeDescriptions.data();
         vertexInputInfo.pVertexBindingDescriptions = &bindingDescription;
 
-        VkGraphicsPipelineCreateInfo pipelineInfo = {
-            .sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO};
+        VkGraphicsPipelineCreateInfo pipelineInfo = {.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO};
         pipelineInfo.pNext = &renderInfo;
 
         pipelineInfo.stageCount = (uint32_t)shaderStages.size();
@@ -96,16 +93,14 @@ namespace IC {
 
         VkDynamicState state[] = {VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR};
 
-        VkPipelineDynamicStateCreateInfo dynamicInfo = {
-            .sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO};
+        VkPipelineDynamicStateCreateInfo dynamicInfo = {.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO};
         dynamicInfo.pDynamicStates = &state[0];
         dynamicInfo.dynamicStateCount = 2;
 
         pipelineInfo.pDynamicState = &dynamicInfo;
 
         VkPipeline newPipeline;
-        if (vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr,
-                                      &newPipeline) != VK_SUCCESS) {
+        if (vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &newPipeline) != VK_SUCCESS) {
             IC_CORE_ERROR("Failed to create graphics pipeline.");
             throw std::runtime_error("Failed to create graphics pipeline.");
         }
@@ -114,15 +109,13 @@ namespace IC {
     }
 
     VkPipeline PipelineBuilder::BuildComputePipeline(VkDevice device) {
-        VkComputePipelineCreateInfo pipelineInfo{
-            .sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO};
+        VkComputePipelineCreateInfo pipelineInfo{.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO};
         pipelineInfo.pNext = nullptr;
         pipelineInfo.stage = shaderStages[0];
         pipelineInfo.layout = pipelineLayout;
 
         VkPipeline newPipeline;
-        if (vkCreateComputePipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr,
-                                     &newPipeline) != VK_SUCCESS) {
+        if (vkCreateComputePipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &newPipeline) != VK_SUCCESS) {
             IC_CORE_ERROR("Failed to create compute pipeline.");
             throw std::runtime_error("Failed to create compute pipeline.");
         }
@@ -164,14 +157,14 @@ namespace IC {
     }
 
     void PipelineBuilder::DisableBlending() {
-        colorBlendAttachment.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
-                                              VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+        colorBlendAttachment.colorWriteMask =
+            VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
         colorBlendAttachment.blendEnable = VK_FALSE;
     }
 
     void PipelineBuilder::EnableBlending() {
-        colorBlendAttachment.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
-                                              VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+        colorBlendAttachment.colorWriteMask =
+            VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
         colorBlendAttachment.blendEnable = VK_TRUE;
         colorBlendAttachment.colorBlendOp = VK_BLEND_OP_ADD;
         colorBlendAttachment.alphaBlendOp = VK_BLEND_OP_SUBTRACT;
@@ -215,10 +208,9 @@ namespace IC {
         depthStencil.maxDepthBounds = 1.f;
     }
 
-    VkPipelineShaderStageCreateInfo
-    PipelineBuilder::ShaderStageCreateInfo(VkShaderStageFlagBits flags, VkShaderModule module) {
-        VkPipelineShaderStageCreateInfo createInfo{
-            .sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO};
+    VkPipelineShaderStageCreateInfo PipelineBuilder::ShaderStageCreateInfo(VkShaderStageFlagBits flags,
+                                                                           VkShaderModule module) {
+        VkPipelineShaderStageCreateInfo createInfo{.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO};
         createInfo.stage = flags;
         createInfo.module = module;
         createInfo.pName = "main";
@@ -226,9 +218,8 @@ namespace IC {
     }
 
     // pipeline manager
-    std::shared_ptr<Pipeline>
-    PipelineManager::FindOrCreateSuitablePipeline(VkDevice device, SwapChain &swapChain,
-                                                  Material &materialData) {
+    std::shared_ptr<Pipeline> PipelineManager::FindOrCreateSuitablePipeline(VkDevice device, SwapChain &swapChain,
+                                                                            Material &materialData) {
         for (auto pipeline : _createdPipelines) {
             if (IsPipelineSuitable(*pipeline, materialData)) {
                 return pipeline;

--- a/src/vulkan/pipelines.cpp
+++ b/src/vulkan/pipelines.cpp
@@ -9,7 +9,7 @@
 #include <iostream>
 #include <stdexcept>
 
-namespace IC::Renderer
+namespace IC
 {
     void PipelineBuilder::clear()
     {

--- a/src/vulkan/pipelines.h
+++ b/src/vulkan/pipelines.h
@@ -1,15 +1,13 @@
 #pragma once
 
+#include "swap_chain.h"
 #include "vulkan_device.h"
 #include "vulkan_types.h"
-#include "swap_chain.h"
 
 #include <memory>
 
-namespace IC
-{
-    class PipelineBuilder
-    {
+namespace IC {
+    class PipelineBuilder {
     public:
         std::vector<VkPipelineShaderStageCreateInfo> shaderStages;
 
@@ -47,13 +45,13 @@ namespace IC
                                                                      VkShaderModule module);
     };
 
-    class PipelineManager
-    {
+    class PipelineManager {
     public:
-        std::shared_ptr<Pipeline> FindOrCreateSuitablePipeline(VkDevice device, SwapChain &swapChain, Material &materialData);
+        std::shared_ptr<Pipeline>
+        FindOrCreateSuitablePipeline(VkDevice device, SwapChain &swapChain, Material &materialData);
 
     private:
         bool IsPipelineSuitable(Pipeline &pipeline, Material &materialData);
         std::vector<std::shared_ptr<Pipeline>> _createdPipelines;
     };
-} // namespace lve
+} // namespace IC

--- a/src/vulkan/pipelines.h
+++ b/src/vulkan/pipelines.h
@@ -6,7 +6,7 @@
 
 #include <memory>
 
-namespace IC::Renderer
+namespace IC
 {
     class PipelineBuilder
     {

--- a/src/vulkan/pipelines.h
+++ b/src/vulkan/pipelines.h
@@ -47,8 +47,8 @@ namespace IC {
 
     class PipelineManager {
     public:
-        std::shared_ptr<Pipeline>
-        FindOrCreateSuitablePipeline(VkDevice device, SwapChain &swapChain, Material &materialData);
+        std::shared_ptr<Pipeline> FindOrCreateSuitablePipeline(VkDevice device, SwapChain &swapChain,
+                                                               Material &materialData);
 
     private:
         bool IsPipelineSuitable(Pipeline &pipeline, Material &materialData);

--- a/src/vulkan/swap_chain.cpp
+++ b/src/vulkan/swap_chain.cpp
@@ -13,8 +13,7 @@
 #include <stdexcept>
 
 namespace IC {
-    SwapChain::SwapChain(VulkanDevice &deviceRef, VkExtent2D extent)
-        : _device{deviceRef}, _windowExtent{extent} {
+    SwapChain::SwapChain(VulkanDevice &deviceRef, VkExtent2D extent) : _device{deviceRef}, _windowExtent{extent} {
         CreateSwapChain();
         CreateImageViews();
         CreateRenderPass();
@@ -60,10 +59,10 @@ namespace IC {
         vkWaitForFences(_device.Device(), 1, &_inFlightFences[_currentFrame], VK_TRUE,
                         std::numeric_limits<uint64_t>::max());
 
-        VkResult result = vkAcquireNextImageKHR(
-            _device.Device(), _swapChain, std::numeric_limits<uint64_t>::max(),
-            _imageAvailableSemaphores[_currentFrame], // must be a not signaled semaphore
-            VK_NULL_HANDLE, imageIndex);
+        VkResult result =
+            vkAcquireNextImageKHR(_device.Device(), _swapChain, std::numeric_limits<uint64_t>::max(),
+                                  _imageAvailableSemaphores[_currentFrame], // must be a not signaled semaphore
+                                  VK_NULL_HANDLE, imageIndex);
 
         return result;
     }
@@ -88,8 +87,7 @@ namespace IC {
         submitInfo.pSignalSemaphores = signalSemaphores;
 
         vkResetFences(_device.Device(), 1, &_inFlightFences[_currentFrame]);
-        VK_CHECK(
-            vkQueueSubmit(_device.GraphicsQueue(), 1, &submitInfo, _inFlightFences[_currentFrame]));
+        VK_CHECK(vkQueueSubmit(_device.GraphicsQueue(), 1, &submitInfo, _inFlightFences[_currentFrame]));
 
         VkPresentInfoKHR presentInfo = {};
         presentInfo.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
@@ -112,19 +110,16 @@ namespace IC {
 
     void SwapChain::WaitForFrameFence(uint32_t *imageIndex) {
         if (_imagesInFlight[*imageIndex] != VK_NULL_HANDLE) {
-            vkWaitForFences(_device.Device(), 1, &_imagesInFlight[*imageIndex], VK_TRUE,
-                            UINT64_MAX);
+            vkWaitForFences(_device.Device(), 1, &_imagesInFlight[*imageIndex], VK_TRUE, UINT64_MAX);
         }
     }
 
-    void
-    SwapChain::ImmediateSubmitCommandBuffers(const VkCommandBuffer buffer,
-                                             std::function<void(VkCommandBuffer cmd)> &&function) {
+    void SwapChain::ImmediateSubmitCommandBuffers(const VkCommandBuffer buffer,
+                                                  std::function<void(VkCommandBuffer cmd)> &&function) {
         VK_CHECK(vkResetFences(_device.Device(), 1, &_immFence));
         VK_CHECK(vkResetCommandBuffer(buffer, 0));
 
-        VkCommandBufferBeginInfo beginInfo =
-            CommandBufferBeginInfo(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
+        VkCommandBufferBeginInfo beginInfo = CommandBufferBeginInfo(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
 
         VK_CHECK(vkBeginCommandBuffer(buffer, &beginInfo));
 
@@ -162,8 +157,7 @@ namespace IC {
         createInfo.imageColorSpace = surfaceFormat.colorSpace;
         createInfo.imageExtent = extent;
         createInfo.imageArrayLayers = 1;
-        createInfo.imageUsage =
-            VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+        createInfo.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
 
         QueueFamilyIndices indices = _device.FindPhysicalQueueFamilies();
         uint32_t queueFamilyIndices[] = {indices.graphicsFamily, indices.presentFamily};
@@ -203,8 +197,7 @@ namespace IC {
     void SwapChain::CreateImageViews() {
         _swapChainImageViews.resize(_swapChainImages.size());
         for (size_t i = 0; i < _swapChainImages.size(); i++) {
-            _swapChainImageViews[i] =
-                _device.CreateImageView(_swapChainImages[i], _swapChainImageFormat);
+            _swapChainImageViews[i] = _device.CreateImageView(_swapChainImages[i], _swapChainImageFormat);
         }
     }
 
@@ -246,13 +239,12 @@ namespace IC {
         VkSubpassDependency dependency = {};
         dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
         dependency.srcAccessMask = 0;
-        dependency.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT |
-                                  VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
+        dependency.srcStageMask =
+            VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT | VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
         dependency.dstSubpass = 0;
-        dependency.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT |
-                                  VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
-        dependency.dstAccessMask =
-            VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+        dependency.dstStageMask =
+            VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT | VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
+        dependency.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
 
         std::array<VkAttachmentDescription, 2> attachments = {colorAttachment, depthAttachment};
         VkRenderPassCreateInfo renderPassInfo = {};
@@ -282,8 +274,7 @@ namespace IC {
             framebufferInfo.height = swapChainExtent.height;
             framebufferInfo.layers = 1;
 
-            VK_CHECK(vkCreateFramebuffer(_device.Device(), &framebufferInfo, nullptr,
-                                         &_swapChainFramebuffers[i]));
+            VK_CHECK(vkCreateFramebuffer(_device.Device(), &framebufferInfo, nullptr, &_swapChainFramebuffers[i]));
         }
     }
 
@@ -312,8 +303,8 @@ namespace IC {
             imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
             imageInfo.flags = 0;
 
-            _device.CreateImageWithInfo(imageInfo, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-                                        _depthImages[i], _depthImageMemorys[i]);
+            _device.CreateImageWithInfo(imageInfo, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, _depthImages[i],
+                                        _depthImageMemorys[i]);
 
             VkImageViewCreateInfo viewInfo{};
             viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
@@ -344,12 +335,11 @@ namespace IC {
         fenceInfo.flags = VK_FENCE_CREATE_SIGNALED_BIT;
 
         for (size_t i = 0; i < MAX_FRAMES_IN_FLIGHT; i++) {
-            if (vkCreateSemaphore(_device.Device(), &semaphoreInfo, nullptr,
-                                  &_imageAvailableSemaphores[i]) != VK_SUCCESS ||
-                vkCreateSemaphore(_device.Device(), &semaphoreInfo, nullptr,
-                                  &_renderFinishedSemaphores[i]) != VK_SUCCESS ||
-                vkCreateFence(_device.Device(), &fenceInfo, nullptr, &_inFlightFences[i]) !=
-                    VK_SUCCESS) {
+            if (vkCreateSemaphore(_device.Device(), &semaphoreInfo, nullptr, &_imageAvailableSemaphores[i]) !=
+                    VK_SUCCESS ||
+                vkCreateSemaphore(_device.Device(), &semaphoreInfo, nullptr, &_renderFinishedSemaphores[i]) !=
+                    VK_SUCCESS ||
+                vkCreateFence(_device.Device(), &fenceInfo, nullptr, &_inFlightFences[i]) != VK_SUCCESS) {
                 IC_CORE_ERROR("Failed to create synchronization objects for a frame.");
                 throw std::runtime_error("Failed to create synchronization objects for a frame.");
             }
@@ -359,8 +349,7 @@ namespace IC {
         VK_CHECK(vkCreateFence(_device.Device(), &fenceInfo, nullptr, &_immFence));
     }
 
-    VkSurfaceFormatKHR
-    SwapChain::ChooseSwapSurfaceFormat(const std::vector<VkSurfaceFormatKHR> &availableFormats) {
+    VkSurfaceFormatKHR SwapChain::ChooseSwapSurfaceFormat(const std::vector<VkSurfaceFormatKHR> &availableFormats) {
         for (const auto &availableFormat : availableFormats) {
             if (availableFormat.format == VK_FORMAT_B8G8R8A8_UNORM &&
                 availableFormat.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR) {
@@ -371,8 +360,7 @@ namespace IC {
         return availableFormats[0];
     }
 
-    VkPresentModeKHR
-    SwapChain::ChooseSwapPresentMode(const std::vector<VkPresentModeKHR> &availablePresentModes) {
+    VkPresentModeKHR SwapChain::ChooseSwapPresentMode(const std::vector<VkPresentModeKHR> &availablePresentModes) {
         for (const auto &availablePresentMode : availablePresentModes) {
             if (availablePresentMode == VK_PRESENT_MODE_MAILBOX_KHR) {
                 IC_CORE_INFO("Present mode: Mailbox");
@@ -396,12 +384,10 @@ namespace IC {
             return capabilities.currentExtent;
         } else {
             VkExtent2D actualExtent = _windowExtent;
-            actualExtent.width =
-                std::max(capabilities.minImageExtent.width,
-                         std::min(capabilities.maxImageExtent.width, actualExtent.width));
-            actualExtent.height =
-                std::max(capabilities.minImageExtent.height,
-                         std::min(capabilities.maxImageExtent.height, actualExtent.height));
+            actualExtent.width = std::max(capabilities.minImageExtent.width,
+                                          std::min(capabilities.maxImageExtent.width, actualExtent.width));
+            actualExtent.height = std::max(capabilities.minImageExtent.height,
+                                           std::min(capabilities.maxImageExtent.height, actualExtent.height));
 
             return actualExtent;
         }
@@ -409,8 +395,8 @@ namespace IC {
 
     VkFormat SwapChain::FindDepthFormat() {
         return _device.FindSupportedFormat(
-            {VK_FORMAT_D32_SFLOAT, VK_FORMAT_D32_SFLOAT_S8_UINT, VK_FORMAT_D24_UNORM_S8_UINT},
-            VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT);
+            {VK_FORMAT_D32_SFLOAT, VK_FORMAT_D32_SFLOAT_S8_UINT, VK_FORMAT_D24_UNORM_S8_UINT}, VK_IMAGE_TILING_OPTIMAL,
+            VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT);
     }
 
 } // namespace IC

--- a/src/vulkan/swap_chain.cpp
+++ b/src/vulkan/swap_chain.cpp
@@ -1,3 +1,4 @@
+#include "ic_log.h"
 #include "swap_chain.h"
 #include "vulkan_types.h"
 #include "vulkan_initializers.h"
@@ -6,12 +7,11 @@
 #include <array>
 #include <cstdlib>
 #include <cstring>
-#include <iostream>
 #include <limits>
 #include <set>
 #include <stdexcept>
 
-namespace IC::Renderer
+namespace IC
 {
 
     SwapChain::SwapChain(VulkanDevice &deviceRef, VkExtent2D extent)
@@ -415,19 +415,19 @@ namespace IC::Renderer
         {
             if (availablePresentMode == VK_PRESENT_MODE_MAILBOX_KHR)
             {
-                std::cout << "Present mode: Mailbox" << std::endl;
+                IC_CORE_INFO("Present mode: Mailbox");
                 return availablePresentMode;
             }
         }
 
         // for (const auto &availablePresentMode : availablePresentModes) {
         //   if (availablePresentMode == VK_PRESENT_MODE_IMMEDIATE_KHR) {
-        //     std::cout << "Present mode: Immediate" << std::endl;
+        //     IC_CORE_INFO("Present mode: Immediate");
         //     return availablePresentMode;
         //   }
         // }
 
-        std::cout << "Present mode: V-Sync" << std::endl;
+        IC_CORE_INFO("Present mode: V-Sync");
         return VK_PRESENT_MODE_FIFO_KHR;
     }
 

--- a/src/vulkan/swap_chain.cpp
+++ b/src/vulkan/swap_chain.cpp
@@ -137,7 +137,7 @@ namespace IC
         VK_CHECK(vkResetCommandBuffer(buffer, 0));
 
         VkCommandBufferBeginInfo beginInfo =
-            Init::CommandBufferBeginInfo(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
+            CommandBufferBeginInfo(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
 
         VK_CHECK(vkBeginCommandBuffer(buffer, &beginInfo));
 
@@ -145,8 +145,8 @@ namespace IC
 
         VK_CHECK(vkEndCommandBuffer(buffer));
 
-        VkCommandBufferSubmitInfo cmdInfo = Init::CommandBufferSubmitInfo(buffer);
-        VkSubmitInfo2 submit = Init::SubmitInfo(&cmdInfo, nullptr, nullptr);
+        VkCommandBufferSubmitInfo cmdInfo = CommandBufferSubmitInfo(buffer);
+        VkSubmitInfo2 submit = SubmitInfo(&cmdInfo, nullptr, nullptr);
 
         VK_CHECK(vkQueueSubmit2(_device.GraphicsQueue(), 1, &submit, _immFence));
 
@@ -384,8 +384,8 @@ namespace IC
                 vkCreateFence(_device.Device(), &fenceInfo, nullptr, &_inFlightFences[i]) !=
                     VK_SUCCESS)
             {
-                throw std::runtime_error(
-                    "failed to create synchronization objects for a frame!");
+                IC_CORE_ERROR("Failed to create synchronization objects for a frame.");
+                throw std::runtime_error("Failed to create synchronization objects for a frame.");
             }
         }
 

--- a/src/vulkan/swap_chain.h
+++ b/src/vulkan/swap_chain.h
@@ -2,19 +2,14 @@
 
 #include "vulkan_device.h"
 
-// vulkan headers
 #include <vulkan/vulkan.h>
 
-// std lib headers
 #include <functional>
 #include <string>
 #include <vector>
 
-namespace IC
-{
-
-    class SwapChain
-    {
+namespace IC {
+    class SwapChain {
     public:
         static constexpr int MAX_FRAMES_IN_FLIGHT = 2;
 
@@ -38,8 +33,7 @@ namespace IC
         uint32_t Width() { return _swapChainExtent.width; }
         uint32_t Height() { return _swapChainExtent.height; }
 
-        float ExtentAspectRatio()
-        {
+        float ExtentAspectRatio() {
             return static_cast<float>(_swapChainExtent.width) /
                    static_cast<float>(_swapChainExtent.height);
         }
@@ -93,4 +87,4 @@ namespace IC
         VkFence _immFence;
     };
 
-} // namespace render
+} // namespace IC

--- a/src/vulkan/swap_chain.h
+++ b/src/vulkan/swap_chain.h
@@ -34,8 +34,7 @@ namespace IC {
         uint32_t Height() { return _swapChainExtent.height; }
 
         float ExtentAspectRatio() {
-            return static_cast<float>(_swapChainExtent.width) /
-                   static_cast<float>(_swapChainExtent.height);
+            return static_cast<float>(_swapChainExtent.width) / static_cast<float>(_swapChainExtent.height);
         }
         VkFormat FindDepthFormat();
 
@@ -54,10 +53,8 @@ namespace IC {
         void CreateSyncObjects();
 
         // Helper functions
-        VkSurfaceFormatKHR
-        ChooseSwapSurfaceFormat(const std::vector<VkSurfaceFormatKHR> &availableFormats);
-        VkPresentModeKHR
-        ChooseSwapPresentMode(const std::vector<VkPresentModeKHR> &availablePresentModes);
+        VkSurfaceFormatKHR ChooseSwapSurfaceFormat(const std::vector<VkSurfaceFormatKHR> &availableFormats);
+        VkPresentModeKHR ChooseSwapPresentMode(const std::vector<VkPresentModeKHR> &availablePresentModes);
         VkExtent2D ChooseSwapExtent(const VkSurfaceCapabilitiesKHR &capabilities);
 
         VkFormat _swapChainImageFormat;

--- a/src/vulkan/swap_chain.h
+++ b/src/vulkan/swap_chain.h
@@ -10,7 +10,7 @@
 #include <string>
 #include <vector>
 
-namespace IC::Renderer
+namespace IC
 {
 
     class SwapChain
@@ -49,7 +49,7 @@ namespace IC::Renderer
         VkResult SubmitCommandBuffers(const VkCommandBuffer *buffers, uint32_t *imageIndex);
         void WaitForFrameFence(uint32_t *imageIndex);
         void ImmediateSubmitCommandBuffers(const VkCommandBuffer buffer,
-                                      std::function<void(VkCommandBuffer cmd)> &&function);
+                                           std::function<void(VkCommandBuffer cmd)> &&function);
 
     private:
         void CreateSwapChain();

--- a/src/vulkan/vulkan_device.cpp
+++ b/src/vulkan/vulkan_device.cpp
@@ -79,7 +79,8 @@ namespace IC
     {
         if (enableValidationLayers && !CheckValidationLayerSupport())
         {
-            throw std::runtime_error("validation layers requested, but not available!");
+            IC_CORE_ERROR("Validation layers requested, but not available.");
+            throw std::runtime_error("Validation layers requested, but not available.");
         }
 
         VkApplicationInfo appInfo = {};
@@ -125,7 +126,8 @@ namespace IC
         vkEnumeratePhysicalDevices(_instance, &deviceCount, nullptr);
         if (deviceCount == 0)
         {
-            throw std::runtime_error("failed to find GPUs with Vulkan support!");
+            IC_CORE_ERROR("Failed to find GPUs with Vulkan support.");
+            throw std::runtime_error("Failed to find GPUs with Vulkan support.");
         }
         IC_CORE_INFO("Device count: {0}", deviceCount);
         std::vector<VkPhysicalDevice> devices(deviceCount);
@@ -142,7 +144,8 @@ namespace IC
 
         if (_physicalDevice == VK_NULL_HANDLE)
         {
-            throw std::runtime_error("failed to find a suitable GPU!");
+            IC_CORE_ERROR("Failed to find a suitable GPU.");
+            throw std::runtime_error("Failed to find a suitable GPU.");
         }
 
         vkGetPhysicalDeviceProperties(_physicalDevice, &properties);
@@ -336,7 +339,8 @@ namespace IC
             IC_CORE_INFO("\t- {0}", required);
             if (available.find(required) == available.end())
             {
-                throw std::runtime_error("Missing required glfw extension");
+                IC_CORE_ERROR("Missing required GLFW extension.");
+                throw std::runtime_error("Missing required GLFW extension.");
             }
         }
     }
@@ -442,7 +446,9 @@ namespace IC
                 return format;
             }
         }
-        throw std::runtime_error("failed to find supported format!");
+
+        IC_CORE_ERROR("Failed to find supported format.");
+        throw std::runtime_error("Failed to find supported format.");
     }
 
     uint32_t VulkanDevice::FindMemoryType(uint32_t typeFilter, VkMemoryPropertyFlags properties)
@@ -458,7 +464,8 @@ namespace IC
             }
         }
 
-        throw std::runtime_error("failed to find suitable memory type!");
+        IC_CORE_ERROR("Failed to find suitable memory type.");
+        throw std::runtime_error("Failed to find suitable memory type.");
     }
 
     void VulkanDevice::CreateBuffer(VkDeviceSize size, VkBufferUsageFlags usage,

--- a/src/vulkan/vulkan_device.cpp
+++ b/src/vulkan/vulkan_device.cpp
@@ -1,3 +1,4 @@
+#include "ic_log.h"
 #include "vulkan_device.h"
 #include "vulkan_types.h"
 
@@ -7,7 +8,7 @@
 #include <set>
 #include <unordered_set>
 
-namespace IC::Renderer
+namespace IC
 {
 
     // local callback functions
@@ -126,7 +127,7 @@ namespace IC::Renderer
         {
             throw std::runtime_error("failed to find GPUs with Vulkan support!");
         }
-        std::cout << "Device count: " << deviceCount << std::endl;
+        IC_CORE_INFO("Device count: {0}", deviceCount);
         std::vector<VkPhysicalDevice> devices(deviceCount);
         vkEnumeratePhysicalDevices(_instance, &deviceCount, devices.data());
 
@@ -145,7 +146,7 @@ namespace IC::Renderer
         }
 
         vkGetPhysicalDeviceProperties(_physicalDevice, &properties);
-        std::cout << "physical device: " << properties.deviceName << std::endl;
+        IC_CORE_INFO("Physical device: {0}", properties.deviceName);
     }
 
     void VulkanDevice::CreateLogicalDevice()
@@ -319,19 +320,20 @@ namespace IC::Renderer
         std::vector<VkExtensionProperties> extensions(extensionCount);
         vkEnumerateInstanceExtensionProperties(nullptr, &extensionCount, extensions.data());
 
-        std::cout << "available extensions:" << std::endl;
+        IC_CORE_INFO("{0} Vulkan extensions available:", extensionCount);
+
         std::unordered_set<std::string> available;
         for (const auto &extension : extensions)
         {
-            std::cout << "\t" << extension.extensionName << std::endl;
+            IC_CORE_INFO("\t- {0}", extension.extensionName);
             available.insert(extension.extensionName);
         }
 
-        std::cout << "required extensions:" << std::endl;
+        IC_CORE_INFO("Required Vulkan extensions:");
         auto requiredExtensions = GetRequiredExtensions();
         for (const auto &required : requiredExtensions)
         {
-            std::cout << "\t" << required << std::endl;
+            IC_CORE_INFO("\t- {0}", required);
             if (available.find(required) == available.end())
             {
                 throw std::runtime_error("Missing required glfw extension");

--- a/src/vulkan/vulkan_device.cpp
+++ b/src/vulkan/vulkan_device.cpp
@@ -10,21 +10,20 @@
 
 namespace IC {
     // local callback functions
-    static VKAPI_ATTR VkBool32 VKAPI_CALL
-    debugCallback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
-                  VkDebugUtilsMessageTypeFlagsEXT messageType,
-                  const VkDebugUtilsMessengerCallbackDataEXT *pCallbackData, void *pUserData) {
+    static VKAPI_ATTR VkBool32 VKAPI_CALL debugCallback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
+                                                        VkDebugUtilsMessageTypeFlagsEXT messageType,
+                                                        const VkDebugUtilsMessengerCallbackDataEXT *pCallbackData,
+                                                        void *pUserData) {
         std::cerr << "validation layer: " << pCallbackData->pMessage << std::endl;
 
         return VK_FALSE;
     }
 
-    VkResult CreateDebugUtilsMessengerEXT(VkInstance instance,
-                                          const VkDebugUtilsMessengerCreateInfoEXT *pCreateInfo,
+    VkResult CreateDebugUtilsMessengerEXT(VkInstance instance, const VkDebugUtilsMessengerCreateInfoEXT *pCreateInfo,
                                           const VkAllocationCallbacks *pAllocator,
                                           VkDebugUtilsMessengerEXT *pDebugMessenger) {
-        auto func = (PFN_vkCreateDebugUtilsMessengerEXT)vkGetInstanceProcAddr(
-            instance, "vkCreateDebugUtilsMessengerEXT");
+        auto func =
+            (PFN_vkCreateDebugUtilsMessengerEXT)vkGetInstanceProcAddr(instance, "vkCreateDebugUtilsMessengerEXT");
         if (func != nullptr) {
             return func(instance, pCreateInfo, pAllocator, pDebugMessenger);
         } else {
@@ -34,8 +33,8 @@ namespace IC {
 
     void DestroyDebugUtilsMessengerEXT(VkInstance instance, VkDebugUtilsMessengerEXT debugMessenger,
                                        const VkAllocationCallbacks *pAllocator) {
-        auto func = (PFN_vkDestroyDebugUtilsMessengerEXT)vkGetInstanceProcAddr(
-            instance, "vkDestroyDebugUtilsMessengerEXT");
+        auto func =
+            (PFN_vkDestroyDebugUtilsMessengerEXT)vkGetInstanceProcAddr(instance, "vkDestroyDebugUtilsMessengerEXT");
         if (func != nullptr) {
             func(instance, debugMessenger, pAllocator);
         }
@@ -186,8 +185,7 @@ namespace IC {
         VkCommandPoolCreateInfo poolInfo = {};
         poolInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
         poolInfo.queueFamilyIndex = queueFamilyIndices.graphicsFamily;
-        poolInfo.flags =
-            VK_COMMAND_POOL_CREATE_TRANSIENT_BIT | VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+        poolInfo.flags = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT | VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
 
         VK_CHECK(vkCreateCommandPool(_device, &poolInfo, nullptr, &_commandPool));
     }
@@ -204,23 +202,20 @@ namespace IC {
         bool swapChainAdequate = false;
         if (extensionsSupported) {
             SwapChainSupportDetails swapChainSupport = QuerySwapChainSupport(device);
-            swapChainAdequate =
-                !swapChainSupport.formats.empty() && !swapChainSupport.presentModes.empty();
+            swapChainAdequate = !swapChainSupport.formats.empty() && !swapChainSupport.presentModes.empty();
         }
 
         VkPhysicalDeviceFeatures supportedFeatures;
         vkGetPhysicalDeviceFeatures(device, &supportedFeatures);
 
-        return indices.IsComplete() && extensionsSupported && swapChainAdequate &&
-               supportedFeatures.samplerAnisotropy;
+        return indices.IsComplete() && extensionsSupported && swapChainAdequate && supportedFeatures.samplerAnisotropy;
     }
 
-    void
-    VulkanDevice::PopulateDebugMessengerCreateInfo(VkDebugUtilsMessengerCreateInfoEXT &createInfo) {
+    void VulkanDevice::PopulateDebugMessengerCreateInfo(VkDebugUtilsMessengerCreateInfoEXT &createInfo) {
         createInfo = {};
         createInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT;
-        createInfo.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT |
-                                     VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+        createInfo.messageSeverity =
+            VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
         createInfo.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT |
                                  VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT |
                                  VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
@@ -307,11 +302,9 @@ namespace IC {
         vkEnumerateDeviceExtensionProperties(device, nullptr, &extensionCount, nullptr);
 
         std::vector<VkExtensionProperties> availableExtensions(extensionCount);
-        vkEnumerateDeviceExtensionProperties(device, nullptr, &extensionCount,
-                                             availableExtensions.data());
+        vkEnumerateDeviceExtensionProperties(device, nullptr, &extensionCount, availableExtensions.data());
 
-        std::set<std::string> requiredExtensions(_deviceExtensions.begin(),
-                                                 _deviceExtensions.end());
+        std::set<std::string> requiredExtensions(_deviceExtensions.begin(), _deviceExtensions.end());
 
         for (const auto &extension : availableExtensions) {
             requiredExtensions.erase(extension.extensionName);
@@ -360,8 +353,7 @@ namespace IC {
 
         if (formatCount != 0) {
             details.formats.resize(formatCount);
-            vkGetPhysicalDeviceSurfaceFormatsKHR(device, _surface, &formatCount,
-                                                 details.formats.data());
+            vkGetPhysicalDeviceSurfaceFormatsKHR(device, _surface, &formatCount, details.formats.data());
         }
 
         uint32_t presentModeCount;
@@ -369,24 +361,20 @@ namespace IC {
 
         if (presentModeCount != 0) {
             details.presentModes.resize(presentModeCount);
-            vkGetPhysicalDeviceSurfacePresentModesKHR(device, _surface, &presentModeCount,
-                                                      details.presentModes.data());
+            vkGetPhysicalDeviceSurfacePresentModesKHR(device, _surface, &presentModeCount, details.presentModes.data());
         }
         return details;
     }
 
-    VkFormat VulkanDevice::FindSupportedFormat(const std::vector<VkFormat> &candidates,
-                                               VkImageTiling tiling,
+    VkFormat VulkanDevice::FindSupportedFormat(const std::vector<VkFormat> &candidates, VkImageTiling tiling,
                                                VkFormatFeatureFlags features) {
         for (VkFormat format : candidates) {
             VkFormatProperties props;
             vkGetPhysicalDeviceFormatProperties(_physicalDevice, format, &props);
 
-            if (tiling == VK_IMAGE_TILING_LINEAR &&
-                (props.linearTilingFeatures & features) == features) {
+            if (tiling == VK_IMAGE_TILING_LINEAR && (props.linearTilingFeatures & features) == features) {
                 return format;
-            } else if (tiling == VK_IMAGE_TILING_OPTIMAL &&
-                       (props.optimalTilingFeatures & features) == features) {
+            } else if (tiling == VK_IMAGE_TILING_OPTIMAL && (props.optimalTilingFeatures & features) == features) {
                 return format;
             }
         }
@@ -399,8 +387,7 @@ namespace IC {
         VkPhysicalDeviceMemoryProperties memProperties;
         vkGetPhysicalDeviceMemoryProperties(_physicalDevice, &memProperties);
         for (uint32_t i = 0; i < memProperties.memoryTypeCount; i++) {
-            if ((typeFilter & (1 << i)) &&
-                (memProperties.memoryTypes[i].propertyFlags & properties) == properties) {
+            if ((typeFilter & (1 << i)) && (memProperties.memoryTypes[i].propertyFlags & properties) == properties) {
                 return i;
             }
         }
@@ -409,9 +396,8 @@ namespace IC {
         throw std::runtime_error("Failed to find suitable memory type.");
     }
 
-    void VulkanDevice::CreateBuffer(VkDeviceSize size, VkBufferUsageFlags usage,
-                                    VkMemoryPropertyFlags properties, VkBuffer &buffer,
-                                    VkDeviceMemory &bufferMemory) {
+    void VulkanDevice::CreateBuffer(VkDeviceSize size, VkBufferUsageFlags usage, VkMemoryPropertyFlags properties,
+                                    VkBuffer &buffer, VkDeviceMemory &bufferMemory) {
         VkBufferCreateInfo bufferInfo{};
         bufferInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
         bufferInfo.size = size;
@@ -477,8 +463,8 @@ namespace IC {
         EndSingleTimeCommands(commandBuffer);
     }
 
-    void VulkanDevice::CopyBufferToImage(VkBuffer buffer, VkImage image, uint32_t width,
-                                         uint32_t height, uint32_t layerCount) {
+    void VulkanDevice::CopyBufferToImage(VkBuffer buffer, VkImage image, uint32_t width, uint32_t height,
+                                         uint32_t layerCount) {
         VkCommandBuffer commandBuffer = BeginSingleTimeCommands();
 
         VkBufferImageCopy region{};
@@ -494,8 +480,7 @@ namespace IC {
         region.imageOffset = {0, 0, 0};
         region.imageExtent = {width, height, 1};
 
-        vkCmdCopyBufferToImage(commandBuffer, buffer, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-                               1, &region);
+        vkCmdCopyBufferToImage(commandBuffer, buffer, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
         EndSingleTimeCommands(commandBuffer);
     }
 
@@ -516,9 +501,8 @@ namespace IC {
         return imageView;
     }
 
-    void VulkanDevice::CreateImageWithInfo(const VkImageCreateInfo &imageInfo,
-                                           VkMemoryPropertyFlags properties, VkImage &image,
-                                           VkDeviceMemory &imageMemory) {
+    void VulkanDevice::CreateImageWithInfo(const VkImageCreateInfo &imageInfo, VkMemoryPropertyFlags properties,
+                                           VkImage &image, VkDeviceMemory &imageMemory) {
         VK_CHECK(vkCreateImage(_device, &imageInfo, nullptr, &image));
 
         VkMemoryRequirements memRequirements;

--- a/src/vulkan/vulkan_device.h
+++ b/src/vulkan/vulkan_device.h
@@ -2,26 +2,21 @@
 
 #define GLFW_INCLUDE_VULKAN
 #include <GLFW/glfw3.h>
-
 #include <vulkan/vulkan.h>
 #include <vulkan/vulkan_beta.h>
 
-// std lib headers
 #include <string>
 #include <vector>
 
-namespace IC
-{
+namespace IC {
 
-    struct SwapChainSupportDetails
-    {
+    struct SwapChainSupportDetails {
         VkSurfaceCapabilitiesKHR capabilities;
         std::vector<VkSurfaceFormatKHR> formats;
         std::vector<VkPresentModeKHR> presentModes;
     };
 
-    struct QueueFamilyIndices
-    {
+    struct QueueFamilyIndices {
         uint32_t graphicsFamily;
         uint32_t presentFamily;
         bool graphicsFamilyHasValue = false;
@@ -29,8 +24,7 @@ namespace IC
         bool IsComplete() { return graphicsFamilyHasValue && presentFamilyHasValue; }
     };
 
-    class VulkanDevice
-    {
+    class VulkanDevice {
     public:
 #ifdef NDEBUG
         const bool enableValidationLayers = false;
@@ -55,15 +49,20 @@ namespace IC
         VkQueue GraphicsQueue() { return _graphicsQueue; }
         VkQueue PresentQueue() { return _presentQueue; }
 
-        SwapChainSupportDetails GetSwapChainSupport() { return QuerySwapChainSupport(_physicalDevice); }
+        SwapChainSupportDetails GetSwapChainSupport() {
+            return QuerySwapChainSupport(_physicalDevice);
+        }
         uint32_t FindMemoryType(uint32_t typeFilter, VkMemoryPropertyFlags properties);
-        QueueFamilyIndices FindPhysicalQueueFamilies() { return FindQueueFamilies(_physicalDevice); }
+        QueueFamilyIndices FindPhysicalQueueFamilies() {
+            return FindQueueFamilies(_physicalDevice);
+        }
         VkFormat FindSupportedFormat(const std::vector<VkFormat> &candidates, VkImageTiling tiling,
                                      VkFormatFeatureFlags features);
 
         // Buffer Helper Functions
-        void CreateBuffer(VkDeviceSize size, VkBufferUsageFlags usage, VkMemoryPropertyFlags properties,
-                          VkBuffer &buffer, VkDeviceMemory &bufferMemory);
+        void CreateBuffer(VkDeviceSize size, VkBufferUsageFlags usage,
+                          VkMemoryPropertyFlags properties, VkBuffer &buffer,
+                          VkDeviceMemory &bufferMemory);
         VkCommandBuffer BeginSingleTimeCommands();
         void EndSingleTimeCommands(VkCommandBuffer commandBuffer);
         void CopyBuffer(VkBuffer srcBuffer, VkBuffer dstBuffer, VkDeviceSize size);
@@ -71,8 +70,9 @@ namespace IC
                                uint32_t layerCount);
         VkImageView CreateImageView(VkImage image, VkFormat format);
 
-        void CreateImageWithInfo(const VkImageCreateInfo &imageInfo, VkMemoryPropertyFlags properties,
-                                 VkImage &image, VkDeviceMemory &imageMemory);
+        void CreateImageWithInfo(const VkImageCreateInfo &imageInfo,
+                                 VkMemoryPropertyFlags properties, VkImage &image,
+                                 VkDeviceMemory &imageMemory);
 
         VkPhysicalDeviceProperties properties;
 
@@ -107,13 +107,13 @@ namespace IC
 
         const std::vector<const char *> _validationLayers = {"VK_LAYER_KHRONOS_validation"};
 #ifdef IC_PLATFORM_MACOS
-        const std::vector<const char *> _deviceExtensions = {VK_KHR_SWAPCHAIN_EXTENSION_NAME,
-                                                             VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME,
-                                                             VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME};
+        const std::vector<const char *> _deviceExtensions = {
+            VK_KHR_SWAPCHAIN_EXTENSION_NAME, VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME,
+            VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME};
 #else
-        const std::vector<const char *> _deviceExtensions = {VK_KHR_SWAPCHAIN_EXTENSION_NAME,
-                                                             VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME};
+        const std::vector<const char *> _deviceExtensions = {
+            VK_KHR_SWAPCHAIN_EXTENSION_NAME, VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME};
 #endif
     };
 
-} // namespace render
+} // namespace IC

--- a/src/vulkan/vulkan_device.h
+++ b/src/vulkan/vulkan_device.h
@@ -31,7 +31,6 @@ namespace IC {
 #else
         const bool enableValidationLayers = true;
 #endif
-
         VulkanDevice(GLFWwindow *window);
         ~VulkanDevice();
 
@@ -41,13 +40,27 @@ namespace IC {
         VulkanDevice(VulkanDevice &&) = delete;
         VulkanDevice &operator=(VulkanDevice &&) = delete;
 
-        VkCommandPool GetCommandPool() { return _commandPool; }
-        VkDevice Device() { return _device; }
-        VkPhysicalDevice PhysicalDevice() { return _physicalDevice; }
-        VkInstance Instance() { return _instance; }
-        VkSurfaceKHR Surface() { return _surface; }
-        VkQueue GraphicsQueue() { return _graphicsQueue; }
-        VkQueue PresentQueue() { return _presentQueue; }
+        VkCommandPool GetCommandPool() {
+            return _commandPool;
+        }
+        VkDevice Device() {
+            return _device;
+        }
+        VkPhysicalDevice PhysicalDevice() {
+            return _physicalDevice;
+        }
+        VkInstance Instance() {
+            return _instance;
+        }
+        VkSurfaceKHR Surface() {
+            return _surface;
+        }
+        VkQueue GraphicsQueue() {
+            return _graphicsQueue;
+        }
+        VkQueue PresentQueue() {
+            return _presentQueue;
+        }
 
         SwapChainSupportDetails GetSwapChainSupport() {
             return QuerySwapChainSupport(_physicalDevice);
@@ -60,18 +73,15 @@ namespace IC {
                                      VkFormatFeatureFlags features);
 
         // Buffer Helper Functions
-        void CreateBuffer(VkDeviceSize size, VkBufferUsageFlags usage,
-                          VkMemoryPropertyFlags properties, VkBuffer &buffer,
-                          VkDeviceMemory &bufferMemory);
+        void CreateBuffer(VkDeviceSize size, VkBufferUsageFlags usage, VkMemoryPropertyFlags properties,
+                          VkBuffer &buffer, VkDeviceMemory &bufferMemory);
         VkCommandBuffer BeginSingleTimeCommands();
         void EndSingleTimeCommands(VkCommandBuffer commandBuffer);
         void CopyBuffer(VkBuffer srcBuffer, VkBuffer dstBuffer, VkDeviceSize size);
-        void CopyBufferToImage(VkBuffer buffer, VkImage image, uint32_t width, uint32_t height,
-                               uint32_t layerCount);
+        void CopyBufferToImage(VkBuffer buffer, VkImage image, uint32_t width, uint32_t height, uint32_t layerCount);
         VkImageView CreateImageView(VkImage image, VkFormat format);
 
-        void CreateImageWithInfo(const VkImageCreateInfo &imageInfo,
-                                 VkMemoryPropertyFlags properties, VkImage &image,
+        void CreateImageWithInfo(const VkImageCreateInfo &imageInfo, VkMemoryPropertyFlags properties, VkImage &image,
                                  VkDeviceMemory &imageMemory);
 
         VkPhysicalDeviceProperties properties;
@@ -107,12 +117,12 @@ namespace IC {
 
         const std::vector<const char *> _validationLayers = {"VK_LAYER_KHRONOS_validation"};
 #ifdef IC_PLATFORM_MACOS
-        const std::vector<const char *> _deviceExtensions = {
-            VK_KHR_SWAPCHAIN_EXTENSION_NAME, VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME,
-            VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME};
+        const std::vector<const char *> _deviceExtensions = {VK_KHR_SWAPCHAIN_EXTENSION_NAME,
+                                                             VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME,
+                                                             VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME};
 #else
-        const std::vector<const char *> _deviceExtensions = {
-            VK_KHR_SWAPCHAIN_EXTENSION_NAME, VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME};
+        const std::vector<const char *> _deviceExtensions = {VK_KHR_SWAPCHAIN_EXTENSION_NAME,
+                                                             VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME};
 #endif
     };
 

--- a/src/vulkan/vulkan_device.h
+++ b/src/vulkan/vulkan_device.h
@@ -10,7 +10,7 @@
 #include <string>
 #include <vector>
 
-namespace IC::Renderer
+namespace IC
 {
 
     struct SwapChainSupportDetails
@@ -108,11 +108,11 @@ namespace IC::Renderer
         const std::vector<const char *> _validationLayers = {"VK_LAYER_KHRONOS_validation"};
 #ifdef IC_PLATFORM_MACOS
         const std::vector<const char *> _deviceExtensions = {VK_KHR_SWAPCHAIN_EXTENSION_NAME,
-                                                            VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME,
-                                                            VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME};
+                                                             VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME,
+                                                             VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME};
 #else
         const std::vector<const char *> _deviceExtensions = {VK_KHR_SWAPCHAIN_EXTENSION_NAME,
-                                                            VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME};
+                                                             VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME};
 #endif
     };
 

--- a/src/vulkan/vulkan_initializers.cpp
+++ b/src/vulkan/vulkan_initializers.cpp
@@ -7,7 +7,7 @@
 
 #include <iostream>
 
-namespace IC::Renderer::Init
+namespace IC::Init
 {
     VkRenderingAttachmentInfo AttachmentInfo(VkImageView view, VkClearValue *clear, VkImageLayout layout)
     {

--- a/src/vulkan/vulkan_initializers.cpp
+++ b/src/vulkan/vulkan_initializers.cpp
@@ -10,8 +10,7 @@
 #include <iostream>
 
 namespace IC {
-    VkRenderingAttachmentInfo AttachmentInfo(VkImageView view, VkClearValue *clear,
-                                             VkImageLayout layout) {
+    VkRenderingAttachmentInfo AttachmentInfo(VkImageView view, VkClearValue *clear, VkImageLayout layout) {
         VkRenderingAttachmentInfo info = {.sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO};
         info.pNext = nullptr;
 
@@ -44,8 +43,7 @@ namespace IC {
         return info;
     }
 
-    VkRenderingInfo RenderingInfo(VkExtent2D renderExtent,
-                                  VkRenderingAttachmentInfo *colorAttachment,
+    VkRenderingInfo RenderingInfo(VkExtent2D renderExtent, VkRenderingAttachmentInfo *colorAttachment,
                                   VkRenderingAttachmentInfo *depthAttachment) {
         VkRenderingInfo info{.sType = VK_STRUCTURE_TYPE_RENDERING_INFO};
         info.pNext = nullptr;
@@ -59,8 +57,7 @@ namespace IC {
         return info;
     }
 
-    VkSubmitInfo2 SubmitInfo(VkCommandBufferSubmitInfo *cmd,
-                             VkSemaphoreSubmitInfo *signalSemaphoreInfo,
+    VkSubmitInfo2 SubmitInfo(VkCommandBufferSubmitInfo *cmd, VkSemaphoreSubmitInfo *signalSemaphoreInfo,
                              VkSemaphoreSubmitInfo *waitSemaphoreInfo) {
         VkSubmitInfo2 info = {.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO_2};
         info.pNext = nullptr;
@@ -75,9 +72,8 @@ namespace IC {
     }
 
     // images
-    void CreateImage(VulkanDevice *device, uint32_t width, uint32_t height, VkFormat format,
-                     VkImageTiling tiling, VkImageUsageFlags usage,
-                     VkMemoryPropertyFlags properties, AllocatedImage &image) {
+    void CreateImage(VulkanDevice *device, uint32_t width, uint32_t height, VkFormat format, VkImageTiling tiling,
+                     VkImageUsageFlags usage, VkMemoryPropertyFlags properties, AllocatedImage &image) {
         VkImageCreateInfo imageInfo{};
         imageInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
         imageInfo.imageType = VK_IMAGE_TYPE_2D;
@@ -94,8 +90,7 @@ namespace IC {
         imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
         imageInfo.flags = 0;
 
-        device->CreateImageWithInfo(imageInfo, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, image.image,
-                                    image.memory);
+        device->CreateImageWithInfo(imageInfo, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, image.image, image.memory);
         image.view = device->CreateImageView(image.image, format);
     }
 
@@ -125,17 +120,14 @@ namespace IC {
     }
 
     // pipelines
-    std::shared_ptr<Pipeline> CreateOpaquePipeline(VkDevice device, SwapChain &swapChain,
-                                                   Material &materialData) {
+    std::shared_ptr<Pipeline> CreateOpaquePipeline(VkDevice device, SwapChain &swapChain, Material &materialData) {
         // descriptor sets
         DescriptorLayoutBuilder descriptorLayoutBuilder{};
-        descriptorLayoutBuilder.AddBinding(
-            0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER); // uniform buffer object
-        descriptorLayoutBuilder.AddBinding(
-            1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER); // constants buffer object
+        descriptorLayoutBuilder.AddBinding(0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER); // uniform buffer object
+        descriptorLayoutBuilder.AddBinding(1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER); // constants buffer object
 
-        VkDescriptorSetLayout descriptorSetLayout = descriptorLayoutBuilder.Build(
-            device, VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT);
+        VkDescriptorSetLayout descriptorSetLayout =
+            descriptorLayoutBuilder.Build(device, VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT);
 
         // pipeline layout
         VkPipelineLayoutCreateInfo pipelineLayoutInfo{};
@@ -149,10 +141,8 @@ namespace IC {
         PipelineBuilder pipelineBuilder;
 
         pipelineBuilder.pipelineLayout = pipelineLayout;
-        VkShaderModule vertShaderModule =
-            PipelineBuilder::CreateShaderModule(device, materialData.vertShaderData);
-        VkShaderModule fragShaderModule =
-            PipelineBuilder::CreateShaderModule(device, materialData.fragShaderData);
+        VkShaderModule vertShaderModule = PipelineBuilder::CreateShaderModule(device, materialData.vertShaderData);
+        VkShaderModule fragShaderModule = PipelineBuilder::CreateShaderModule(device, materialData.fragShaderData);
 
         pipelineBuilder.SetShaders(vertShaderModule, fragShaderModule);
         pipelineBuilder.SetInputTopology(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST);

--- a/src/vulkan/vulkan_initializers.cpp
+++ b/src/vulkan/vulkan_initializers.cpp
@@ -150,9 +150,9 @@ namespace IC {
 
         pipelineBuilder.pipelineLayout = pipelineLayout;
         VkShaderModule vertShaderModule =
-            PipelineBuilder::CreateShaderModule(device, materialData.VertShaderData);
+            PipelineBuilder::CreateShaderModule(device, materialData.vertShaderData);
         VkShaderModule fragShaderModule =
-            PipelineBuilder::CreateShaderModule(device, materialData.FragShaderData);
+            PipelineBuilder::CreateShaderModule(device, materialData.fragShaderData);
 
         pipelineBuilder.SetShaders(vertShaderModule, fragShaderModule);
         pipelineBuilder.SetInputTopology(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST);

--- a/src/vulkan/vulkan_initializers.cpp
+++ b/src/vulkan/vulkan_initializers.cpp
@@ -1,3 +1,5 @@
+#include <ic_log.h>
+
 #include "vulkan_initializers.h"
 
 #include "pipelines.h"
@@ -7,7 +9,7 @@
 
 #include <iostream>
 
-namespace IC::Init
+namespace IC
 {
     VkRenderingAttachmentInfo AttachmentInfo(VkImageView view, VkClearValue *clear, VkImageLayout layout)
     {
@@ -121,7 +123,8 @@ namespace IC::Init
 
         if (vkCreateSampler(device, &samplerInfo, nullptr, &textureSampler) != VK_SUCCESS)
         {
-            throw std::runtime_error("failed to create texture sampler!");
+            IC_CORE_ERROR("Failed to create texture sampler.");
+            throw std::runtime_error("Failed to create texture sampler.");
         }
     }
 

--- a/src/vulkan/vulkan_initializers.cpp
+++ b/src/vulkan/vulkan_initializers.cpp
@@ -1,18 +1,17 @@
-#include <ic_log.h>
-
 #include "vulkan_initializers.h"
 
+#include <ic_log.h>
+
+#include "descriptors.h"
 #include "pipelines.h"
 #include "swap_chain.h"
-#include "descriptors.h"
 #include "vulkan_util.h"
 
 #include <iostream>
 
-namespace IC
-{
-    VkRenderingAttachmentInfo AttachmentInfo(VkImageView view, VkClearValue *clear, VkImageLayout layout)
-    {
+namespace IC {
+    VkRenderingAttachmentInfo AttachmentInfo(VkImageView view, VkClearValue *clear,
+                                             VkImageLayout layout) {
         VkRenderingAttachmentInfo info = {.sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO};
         info.pNext = nullptr;
 
@@ -20,16 +19,14 @@ namespace IC
         info.imageLayout = layout;
         info.loadOp = clear ? VK_ATTACHMENT_LOAD_OP_CLEAR : VK_ATTACHMENT_LOAD_OP_LOAD;
         info.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-        if (clear)
-        {
+        if (clear) {
             info.clearValue = *clear;
         }
 
         return info;
     }
 
-    VkCommandBufferBeginInfo CommandBufferBeginInfo(VkCommandBufferUsageFlags flags /*= 0*/)
-    {
+    VkCommandBufferBeginInfo CommandBufferBeginInfo(VkCommandBufferUsageFlags flags /*= 0*/) {
         VkCommandBufferBeginInfo info = {.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
         info.pNext = nullptr;
         info.pInheritanceInfo = nullptr;
@@ -38,8 +35,7 @@ namespace IC
         return info;
     }
 
-    VkCommandBufferSubmitInfo CommandBufferSubmitInfo(VkCommandBuffer cmd)
-    {
+    VkCommandBufferSubmitInfo CommandBufferSubmitInfo(VkCommandBuffer cmd) {
         VkCommandBufferSubmitInfo info = {.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_SUBMIT_INFO};
         info.pNext = nullptr;
         info.commandBuffer = cmd;
@@ -48,8 +44,9 @@ namespace IC
         return info;
     }
 
-    VkRenderingInfo RenderingInfo(VkExtent2D renderExtent, VkRenderingAttachmentInfo *colorAttachment, VkRenderingAttachmentInfo *depthAttachment)
-    {
+    VkRenderingInfo RenderingInfo(VkExtent2D renderExtent,
+                                  VkRenderingAttachmentInfo *colorAttachment,
+                                  VkRenderingAttachmentInfo *depthAttachment) {
         VkRenderingInfo info{.sType = VK_STRUCTURE_TYPE_RENDERING_INFO};
         info.pNext = nullptr;
         info.renderArea = VkRect2D{VkOffset2D{0, 0}, renderExtent};
@@ -62,8 +59,9 @@ namespace IC
         return info;
     }
 
-    VkSubmitInfo2 SubmitInfo(VkCommandBufferSubmitInfo *cmd, VkSemaphoreSubmitInfo *signalSemaphoreInfo, VkSemaphoreSubmitInfo *waitSemaphoreInfo)
-    {
+    VkSubmitInfo2 SubmitInfo(VkCommandBufferSubmitInfo *cmd,
+                             VkSemaphoreSubmitInfo *signalSemaphoreInfo,
+                             VkSemaphoreSubmitInfo *waitSemaphoreInfo) {
         VkSubmitInfo2 info = {.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO_2};
         info.pNext = nullptr;
         info.waitSemaphoreInfoCount = waitSemaphoreInfo == nullptr ? 0 : 1;
@@ -78,9 +76,8 @@ namespace IC
 
     // images
     void CreateImage(VulkanDevice *device, uint32_t width, uint32_t height, VkFormat format,
-                     VkImageTiling tiling, VkImageUsageFlags usage, VkMemoryPropertyFlags properties,
-                     AllocatedImage &image)
-    {
+                     VkImageTiling tiling, VkImageUsageFlags usage,
+                     VkMemoryPropertyFlags properties, AllocatedImage &image) {
         VkImageCreateInfo imageInfo{};
         imageInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
         imageInfo.imageType = VK_IMAGE_TYPE_2D;
@@ -97,12 +94,12 @@ namespace IC
         imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
         imageInfo.flags = 0;
 
-        device->CreateImageWithInfo(imageInfo, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, image.image, image.memory);
+        device->CreateImageWithInfo(imageInfo, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, image.image,
+                                    image.memory);
         image.view = device->CreateImageView(image.image, format);
     }
 
-    void CreateImageSampler(VkDevice device, float maxAnisotropy, VkSampler &textureSampler)
-    {
+    void CreateImageSampler(VkDevice device, float maxAnisotropy, VkSampler &textureSampler) {
         VkSamplerCreateInfo samplerInfo{};
         samplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
         samplerInfo.magFilter = VK_FILTER_LINEAR;
@@ -121,22 +118,24 @@ namespace IC
         samplerInfo.minLod = 0.0f;
         samplerInfo.maxLod = 0.0f;
 
-        if (vkCreateSampler(device, &samplerInfo, nullptr, &textureSampler) != VK_SUCCESS)
-        {
+        if (vkCreateSampler(device, &samplerInfo, nullptr, &textureSampler) != VK_SUCCESS) {
             IC_CORE_ERROR("Failed to create texture sampler.");
             throw std::runtime_error("Failed to create texture sampler.");
         }
     }
 
     // pipelines
-    std::shared_ptr<Pipeline> CreateOpaquePipeline(VkDevice device, SwapChain &swapChain, Material &materialData)
-    {
+    std::shared_ptr<Pipeline> CreateOpaquePipeline(VkDevice device, SwapChain &swapChain,
+                                                   Material &materialData) {
         // descriptor sets
         DescriptorLayoutBuilder descriptorLayoutBuilder{};
-        descriptorLayoutBuilder.AddBinding(0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER); // uniform buffer object
-        descriptorLayoutBuilder.AddBinding(1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER); // constants buffer object
+        descriptorLayoutBuilder.AddBinding(
+            0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER); // uniform buffer object
+        descriptorLayoutBuilder.AddBinding(
+            1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER); // constants buffer object
 
-        VkDescriptorSetLayout descriptorSetLayout = descriptorLayoutBuilder.Build(device, VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT);
+        VkDescriptorSetLayout descriptorSetLayout = descriptorLayoutBuilder.Build(
+            device, VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT);
 
         // pipeline layout
         VkPipelineLayoutCreateInfo pipelineLayoutInfo{};
@@ -150,8 +149,10 @@ namespace IC
         PipelineBuilder pipelineBuilder;
 
         pipelineBuilder.pipelineLayout = pipelineLayout;
-        VkShaderModule vertShaderModule = PipelineBuilder::CreateShaderModule(device, materialData.VertShaderData);
-        VkShaderModule fragShaderModule = PipelineBuilder::CreateShaderModule(device, materialData.FragShaderData);
+        VkShaderModule vertShaderModule =
+            PipelineBuilder::CreateShaderModule(device, materialData.VertShaderData);
+        VkShaderModule fragShaderModule =
+            PipelineBuilder::CreateShaderModule(device, materialData.FragShaderData);
 
         pipelineBuilder.SetShaders(vertShaderModule, fragShaderModule);
         pipelineBuilder.SetInputTopology(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST);
@@ -172,4 +173,4 @@ namespace IC
 
         return pipeline;
     }
-}
+} // namespace IC

--- a/src/vulkan/vulkan_initializers.h
+++ b/src/vulkan/vulkan_initializers.h
@@ -4,7 +4,7 @@
 #include "vulkan_device.h"
 #include "vulkan_types.h"
 
-namespace IC::Init
+namespace IC
 {
     // initial structures
     VkRenderingAttachmentInfo AttachmentInfo(VkImageView view, VkClearValue *clear, VkImageLayout layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);

--- a/src/vulkan/vulkan_initializers.h
+++ b/src/vulkan/vulkan_initializers.h
@@ -4,18 +4,21 @@
 #include "vulkan_device.h"
 #include "vulkan_types.h"
 
-namespace IC
-{
+namespace IC {
     // initial structures
-    VkRenderingAttachmentInfo AttachmentInfo(VkImageView view, VkClearValue *clear, VkImageLayout layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+    VkRenderingAttachmentInfo
+    AttachmentInfo(VkImageView view, VkClearValue *clear,
+                   VkImageLayout layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
     VkCommandBufferBeginInfo CommandBufferBeginInfo(VkCommandBufferUsageFlags flags = 0);
     VkCommandBufferSubmitInfo CommandBufferSubmitInfo(VkCommandBuffer cmd);
-    VkRenderingInfo RenderingInfo(VkExtent2D renderExtent, VkRenderingAttachmentInfo *colorAttachment, VkRenderingAttachmentInfo *depthAttachment);
-    VkSubmitInfo2 SubmitInfo(VkCommandBufferSubmitInfo *cmd, VkSemaphoreSubmitInfo *signalSemaphoreInfo, VkSemaphoreSubmitInfo *waitSemaphoreInfo);
+    VkRenderingInfo RenderingInfo(VkExtent2D renderExtent,
+                                  VkRenderingAttachmentInfo *colorAttachment,
+                                  VkRenderingAttachmentInfo *depthAttachment);
+    VkSubmitInfo2 SubmitInfo(VkCommandBufferSubmitInfo *cmd,
+                             VkSemaphoreSubmitInfo *signalSemaphoreInfo,
+                             VkSemaphoreSubmitInfo *waitSemaphoreInfo);
 
-    template <typename T>
-    VkPushConstantRange PushConstants(VkShaderStageFlags flags)
-    {
+    template <typename T> VkPushConstantRange PushConstants(VkShaderStageFlags flags) {
         VkPushConstantRange pushConstant{};
         pushConstant.offset = 0;
         pushConstant.size = sizeof(T);
@@ -25,10 +28,11 @@ namespace IC
 
     // images
     void CreateImage(VulkanDevice *device, uint32_t width, uint32_t height, VkFormat format,
-                     VkImageTiling tiling, VkImageUsageFlags usage, VkMemoryPropertyFlags properties,
-                     AllocatedImage &image);
+                     VkImageTiling tiling, VkImageUsageFlags usage,
+                     VkMemoryPropertyFlags properties, AllocatedImage &image);
     void CreateImageSampler(VkDevice device, float maxAnisotropy, VkSampler &textureSampler);
 
     // pipelines
-    std::shared_ptr<Pipeline> CreateOpaquePipeline(VkDevice device, SwapChain &swapChain, Material &materialData);
-}
+    std::shared_ptr<Pipeline> CreateOpaquePipeline(VkDevice device, SwapChain &swapChain,
+                                                   Material &materialData);
+} // namespace IC

--- a/src/vulkan/vulkan_initializers.h
+++ b/src/vulkan/vulkan_initializers.h
@@ -6,16 +6,13 @@
 
 namespace IC {
     // initial structures
-    VkRenderingAttachmentInfo
-    AttachmentInfo(VkImageView view, VkClearValue *clear,
-                   VkImageLayout layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+    VkRenderingAttachmentInfo AttachmentInfo(VkImageView view, VkClearValue *clear,
+                                             VkImageLayout layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
     VkCommandBufferBeginInfo CommandBufferBeginInfo(VkCommandBufferUsageFlags flags = 0);
     VkCommandBufferSubmitInfo CommandBufferSubmitInfo(VkCommandBuffer cmd);
-    VkRenderingInfo RenderingInfo(VkExtent2D renderExtent,
-                                  VkRenderingAttachmentInfo *colorAttachment,
+    VkRenderingInfo RenderingInfo(VkExtent2D renderExtent, VkRenderingAttachmentInfo *colorAttachment,
                                   VkRenderingAttachmentInfo *depthAttachment);
-    VkSubmitInfo2 SubmitInfo(VkCommandBufferSubmitInfo *cmd,
-                             VkSemaphoreSubmitInfo *signalSemaphoreInfo,
+    VkSubmitInfo2 SubmitInfo(VkCommandBufferSubmitInfo *cmd, VkSemaphoreSubmitInfo *signalSemaphoreInfo,
                              VkSemaphoreSubmitInfo *waitSemaphoreInfo);
 
     template <typename T> VkPushConstantRange PushConstants(VkShaderStageFlags flags) {
@@ -27,12 +24,10 @@ namespace IC {
     }
 
     // images
-    void CreateImage(VulkanDevice *device, uint32_t width, uint32_t height, VkFormat format,
-                     VkImageTiling tiling, VkImageUsageFlags usage,
-                     VkMemoryPropertyFlags properties, AllocatedImage &image);
+    void CreateImage(VulkanDevice *device, uint32_t width, uint32_t height, VkFormat format, VkImageTiling tiling,
+                     VkImageUsageFlags usage, VkMemoryPropertyFlags properties, AllocatedImage &image);
     void CreateImageSampler(VkDevice device, float maxAnisotropy, VkSampler &textureSampler);
 
     // pipelines
-    std::shared_ptr<Pipeline> CreateOpaquePipeline(VkDevice device, SwapChain &swapChain,
-                                                   Material &materialData);
+    std::shared_ptr<Pipeline> CreateOpaquePipeline(VkDevice device, SwapChain &swapChain, Material &materialData);
 } // namespace IC

--- a/src/vulkan/vulkan_initializers.h
+++ b/src/vulkan/vulkan_initializers.h
@@ -4,7 +4,7 @@
 #include "vulkan_device.h"
 #include "vulkan_types.h"
 
-namespace IC::Renderer::Init
+namespace IC::Init
 {
     // initial structures
     VkRenderingAttachmentInfo AttachmentInfo(VkImageView view, VkClearValue *clear, VkImageLayout layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);

--- a/src/vulkan/vulkan_renderer.cpp
+++ b/src/vulkan/vulkan_renderer.cpp
@@ -1,33 +1,32 @@
+#include "vulkan_renderer.h"
+
 #include <ic_log.h>
 
 #include "vulkan_initializers.h"
-#include "vulkan_renderer.h"
 #include "vulkan_util.h"
 
 #include <glm/gtc/matrix_transform.hpp>
 
 #include <iostream>
 
-namespace IC
-{
-    Renderer *Renderer::MakeVulkan(RendererConfig &rendererConfig)
-    {
+namespace IC {
+    Renderer *Renderer::MakeVulkan(RendererConfig &rendererConfig) {
         return new VulkanRenderer(rendererConfig);
     }
 
-    VulkanRenderer::VulkanRenderer(RendererConfig &config) : Renderer{config}, _swapChain{_vulkanDevice, {static_cast<uint32_t>(config.Width), static_cast<uint32_t>(config.Height)}}
-    {
+    VulkanRenderer::VulkanRenderer(RendererConfig &config)
+        : Renderer{config},
+          _swapChain{_vulkanDevice,
+                     {static_cast<uint32_t>(config.Width), static_cast<uint32_t>(config.Height)}} {
         CreateCommandBuffers();
         InitDescriptorAllocator();
     }
 
-    VulkanRenderer::~VulkanRenderer()
-    {
+    VulkanRenderer::~VulkanRenderer() {
         _descriptorAllocator.DestroyDescriptorPool(_vulkanDevice.Device());
     }
 
-    void VulkanRenderer::CreateCommandBuffers()
-    {
+    void VulkanRenderer::CreateCommandBuffers() {
         _cBuffers.resize(_swapChain.ImageCount());
 
         VkCommandBufferAllocateInfo allocInfo{};
@@ -39,16 +38,14 @@ namespace IC
         VK_CHECK(vkAllocateCommandBuffers(_vulkanDevice.Device(), &allocInfo, _cBuffers.data()));
     }
 
-    void VulkanRenderer::DrawFrame()
-    {
+    void VulkanRenderer::DrawFrame() {
         static float rotation = 0.0f;
         rotation += 0.01f;
 
         uint32_t imageIndex;
         auto result = _swapChain.AcquireNextImage(&imageIndex);
 
-        if (result != VK_SUCCESS && result != VK_SUBOPTIMAL_KHR)
-        {
+        if (result != VK_SUCCESS && result != VK_SUBOPTIMAL_KHR) {
             IC_CORE_ERROR("Failed to acquire swap chain image.");
             throw std::runtime_error("Failed to acquire swap chain image.");
         }
@@ -59,20 +56,21 @@ namespace IC
 
         VkCommandBufferBeginInfo beginInfo = CommandBufferBeginInfo();
 
-        if (vkBeginCommandBuffer(_cBuffers[imageIndex], &beginInfo) != VK_SUCCESS)
-        {
+        if (vkBeginCommandBuffer(_cBuffers[imageIndex], &beginInfo) != VK_SUCCESS) {
             IC_CORE_ERROR("Failed to begin recording command buffer.");
             throw std::runtime_error("Failed to begin recording command buffer.");
         }
 
-        VkRenderingAttachmentInfo colorAttachment = {.sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO};
+        VkRenderingAttachmentInfo colorAttachment = {
+            .sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO};
         colorAttachment.imageView = _swapChain.GetImageView(imageIndex);
         colorAttachment.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
         colorAttachment.clearValue = {0.1f, 0.1f, 0.1f, 1.0f};
         colorAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
         colorAttachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
 
-        VkRenderingAttachmentInfo depthAttachment{.sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO};
+        VkRenderingAttachmentInfo depthAttachment{.sType =
+                                                      VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO};
         depthAttachment.imageView = _swapChain.GetDepthImageView(imageIndex);
         depthAttachment.imageLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
         depthAttachment.clearValue.depthStencil = {1.0f, 0};
@@ -105,98 +103,120 @@ namespace IC
 
         vkCmdSetScissor(_cBuffers[imageIndex], 0, 1, &scissor);
 
-        // transitioning to COLOR_ATTACHMENT_OPTIMAL for imgui, imgui expects image to be in this format
-        // todo: actually implement imgui
-        TransitionImageLayout(_cBuffers[imageIndex], _swapChain.GetImage(imageIndex), _swapChain.GetSwapChainImageFormat(), VK_IMAGE_LAYOUT_UNDEFINED,
+        // transitioning to COLOR_ATTACHMENT_OPTIMAL for imgui, imgui expects image to be in this
+        // format todo: actually implement imgui
+        TransitionImageLayout(_cBuffers[imageIndex], _swapChain.GetImage(imageIndex),
+                              _swapChain.GetSwapChainImageFormat(), VK_IMAGE_LAYOUT_UNDEFINED,
                               VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 
         auto function = vkGetInstanceProcAddr(_vulkanDevice.Instance(), "vkCmdBeginRenderingKHR");
         ((PFN_vkCmdBeginRenderingKHR)function)(_cBuffers[imageIndex], &renderingInfo);
 
-        for (MeshRenderData data : _renderData)
-        {
+        for (MeshRenderData data : _renderData) {
             // bind pipeline todo: only bind if different
-            vkCmdBindPipeline(_cBuffers[imageIndex], VK_PIPELINE_BIND_POINT_GRAPHICS, data.renderPipeline->pipeline);
+            vkCmdBindPipeline(_cBuffers[imageIndex], VK_PIPELINE_BIND_POINT_GRAPHICS,
+                              data.renderPipeline->pipeline);
 
             MVPObject ubo{};
             // hard coded for now
-            ubo.model = glm::rotate(glm::scale(glm::mat4(1.0f), {0.2f, 0.2f, 0.2f}), rotation, {0.0f, 0.0f, 1.0f});
-            ubo.view = glm::lookAt(glm::vec3(2.0f, 2.0f, 2.0f), glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(0.0f, 0.0f, 1.0f));
-            ubo.proj = glm::perspective(glm::radians(45.0f), (float)_swapChain.GetSwapChainExtent().width / _swapChain.GetSwapChainExtent().height, 0.1f, 10.0f);
+            ubo.model = glm::rotate(glm::scale(glm::mat4(1.0f), {0.2f, 0.2f, 0.2f}), rotation,
+                                    {0.0f, 0.0f, 1.0f});
+            ubo.view = glm::lookAt(glm::vec3(2.0f, 2.0f, 2.0f), glm::vec3(0.0f, 0.0f, 0.0f),
+                                   glm::vec3(0.0f, 0.0f, 1.0f));
+            ubo.proj = glm::perspective(glm::radians(45.0f),
+                                        (float)_swapChain.GetSwapChainExtent().width /
+                                            _swapChain.GetSwapChainExtent().height,
+                                        0.1f, 10.0f);
 
             data.UpdateMvpBuffer(ubo, _swapChain.GetCurrentFrame());
-            data.Bind(_cBuffers[imageIndex], data.renderPipeline->layout, _swapChain.GetCurrentFrame());
+            data.Bind(_cBuffers[imageIndex], data.renderPipeline->layout,
+                      _swapChain.GetCurrentFrame());
             data.Draw(_cBuffers[imageIndex]);
         }
 
         auto function2 = vkGetInstanceProcAddr(_vulkanDevice.Instance(), "vkCmdEndRenderingKHR");
         ((PFN_vkCmdEndRenderingKHR)function2)(_cBuffers[imageIndex]);
 
-        TransitionImageLayout(_cBuffers[imageIndex], _swapChain.GetImage(imageIndex), _swapChain.GetSwapChainImageFormat(),
-                              VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+        TransitionImageLayout(_cBuffers[imageIndex], _swapChain.GetImage(imageIndex),
+                              _swapChain.GetSwapChainImageFormat(),
+                              VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+                              VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
 
-        if (vkEndCommandBuffer(_cBuffers[imageIndex]) != VK_SUCCESS)
-        {
+        if (vkEndCommandBuffer(_cBuffers[imageIndex]) != VK_SUCCESS) {
             IC_CORE_ERROR("Failed to record command buffer.");
             throw std::runtime_error("Failed to record command buffer.");
         }
 
         result = _swapChain.SubmitCommandBuffers(&_cBuffers[imageIndex], &imageIndex);
-        if (result != VK_SUCCESS)
-        {
+        if (result != VK_SUCCESS) {
             IC_CORE_ERROR("Failed to present swap chain image.");
             throw std::runtime_error("Failed to present swap chain image.");
         }
     }
 
-    void VulkanRenderer::InitDescriptorAllocator()
-    {
+    void VulkanRenderer::InitDescriptorAllocator() {
         std::vector<VkDescriptorPoolSize> poolSizes{};
-        poolSizes.push_back({VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, static_cast<uint32_t>(SwapChain::MAX_FRAMES_IN_FLIGHT)});
-        poolSizes.push_back({VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, static_cast<uint32_t>(SwapChain::MAX_FRAMES_IN_FLIGHT)});
-        poolSizes.push_back({VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, static_cast<uint32_t>(SwapChain::MAX_FRAMES_IN_FLIGHT)});
+        poolSizes.push_back({VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+                             static_cast<uint32_t>(SwapChain::MAX_FRAMES_IN_FLIGHT)});
+        poolSizes.push_back({VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+                             static_cast<uint32_t>(SwapChain::MAX_FRAMES_IN_FLIGHT)});
+        poolSizes.push_back({VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+                             static_cast<uint32_t>(SwapChain::MAX_FRAMES_IN_FLIGHT)});
 
         _descriptorAllocator.CreateDescriptorPool(_vulkanDevice.Device(), poolSizes, 100);
     }
 
     // Adds a mesh and associated material to list of renderable objects
-    void VulkanRenderer::AddMesh(Mesh &meshData, Material &materialData)
-    {
-        MeshRenderData meshRenderData{
-            .meshData = meshData,
-            .materialData = materialData};
+    void VulkanRenderer::AddMesh(Mesh &meshData, Material &materialData) {
+        MeshRenderData meshRenderData{.meshData = meshData, .materialData = materialData};
 
-        meshRenderData.renderPipeline = _pipelineManager.FindOrCreateSuitablePipeline(_vulkanDevice.Device(), _swapChain, materialData);
+        meshRenderData.renderPipeline = _pipelineManager.FindOrCreateSuitablePipeline(
+            _vulkanDevice.Device(), _swapChain, materialData);
 
         // buffers
-        CreateAndFillBuffer(_vulkanDevice, meshData.Vertices.data(), sizeof(meshData.Vertices[0]) * meshData.VertexCount, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, meshRenderData.vertexBuffer);
-        CreateAndFillBuffer(_vulkanDevice, meshData.Indices.data(), sizeof(meshData.Indices[0]) * meshData.IndexCount, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, meshRenderData.indexBuffer);
+        CreateAndFillBuffer(_vulkanDevice, meshData.Vertices.data(),
+                            sizeof(meshData.Vertices[0]) * meshData.VertexCount,
+                            VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+                            meshRenderData.vertexBuffer);
+        CreateAndFillBuffer(_vulkanDevice, meshData.Indices.data(),
+                            sizeof(meshData.Indices[0]) * meshData.IndexCount,
+                            VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+                            meshRenderData.indexBuffer);
 
         meshRenderData.mvpBuffers.resize(SwapChain::MAX_FRAMES_IN_FLIGHT);
         meshRenderData.constantsBuffers.resize(SwapChain::MAX_FRAMES_IN_FLIGHT);
-        for (size_t i = 0; i < SwapChain::MAX_FRAMES_IN_FLIGHT; i++)
-        {
-            _vulkanDevice.CreateBuffer(sizeof(MVPObject), VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
-                                       VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-                                       meshRenderData.mvpBuffers[i].buffer, meshRenderData.mvpBuffers[i].memory);
+        for (size_t i = 0; i < SwapChain::MAX_FRAMES_IN_FLIGHT; i++) {
+            _vulkanDevice.CreateBuffer(
+                sizeof(MVPObject), VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
+                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+                meshRenderData.mvpBuffers[i].buffer, meshRenderData.mvpBuffers[i].memory);
 
-            CreateAndFillBuffer(_vulkanDevice, &materialData.Constants, sizeof(MaterialConstants), VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, meshRenderData.constantsBuffers[i]);
+            CreateAndFillBuffer(_vulkanDevice, &materialData.Constants, sizeof(MaterialConstants),
+                                VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
+                                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
+                                meshRenderData.constantsBuffers[i]);
 
-            vkMapMemory(_vulkanDevice.Device(), meshRenderData.mvpBuffers[i].memory, 0, sizeof(MVPObject), 0, &meshRenderData.mvpBuffers[i].mapped_memory);
-            vkMapMemory(_vulkanDevice.Device(), meshRenderData.constantsBuffers[i].memory, 0, sizeof(MaterialConstants), 0, &meshRenderData.constantsBuffers[i].mapped_memory);
+            vkMapMemory(_vulkanDevice.Device(), meshRenderData.mvpBuffers[i].memory, 0,
+                        sizeof(MVPObject), 0, &meshRenderData.mvpBuffers[i].mapped_memory);
+            vkMapMemory(_vulkanDevice.Device(), meshRenderData.constantsBuffers[i].memory, 0,
+                        sizeof(MaterialConstants), 0,
+                        &meshRenderData.constantsBuffers[i].mapped_memory);
         }
 
         // write descriptor sets
-        _descriptorAllocator.AllocateDescriptorSets(_vulkanDevice.Device(), meshRenderData.renderPipeline->descriptorSetLayout, meshRenderData.descriptorSets);
+        _descriptorAllocator.AllocateDescriptorSets(
+            _vulkanDevice.Device(), meshRenderData.renderPipeline->descriptorSetLayout,
+            meshRenderData.descriptorSets);
         DescriptorWriter writer{};
-        for (size_t i = 0; i < SwapChain::MAX_FRAMES_IN_FLIGHT; i++)
-        {
-            writer.WriteBuffer(0, meshRenderData.mvpBuffers[i].buffer, sizeof(MVPObject), 0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
-            writer.WriteBuffer(1, meshRenderData.constantsBuffers[i].buffer, sizeof(MaterialConstants), 0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
+        for (size_t i = 0; i < SwapChain::MAX_FRAMES_IN_FLIGHT; i++) {
+            writer.WriteBuffer(0, meshRenderData.mvpBuffers[i].buffer, sizeof(MVPObject), 0,
+                               VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
+            writer.WriteBuffer(1, meshRenderData.constantsBuffers[i].buffer,
+                               sizeof(MaterialConstants), 0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
 
             writer.UpdateSet(_vulkanDevice.Device(), meshRenderData.descriptorSets[i]);
         }
 
         _renderData.push_back(meshRenderData);
     }
-}
+} // namespace IC

--- a/src/vulkan/vulkan_renderer.cpp
+++ b/src/vulkan/vulkan_renderer.cpp
@@ -17,7 +17,7 @@ namespace IC {
     VulkanRenderer::VulkanRenderer(RendererConfig &config)
         : Renderer{config},
           _swapChain{_vulkanDevice,
-                     {static_cast<uint32_t>(config.Width), static_cast<uint32_t>(config.Height)}} {
+                     {static_cast<uint32_t>(config.width), static_cast<uint32_t>(config.height)}} {
         CreateCommandBuffers();
         InitDescriptorAllocator();
     }
@@ -174,12 +174,12 @@ namespace IC {
             _vulkanDevice.Device(), _swapChain, materialData);
 
         // buffers
-        CreateAndFillBuffer(_vulkanDevice, meshData.Vertices.data(),
-                            sizeof(meshData.Vertices[0]) * meshData.VertexCount,
+        CreateAndFillBuffer(_vulkanDevice, meshData.vertices.data(),
+                            sizeof(meshData.vertices[0]) * meshData.vertexCount,
                             VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
                             meshRenderData.vertexBuffer);
-        CreateAndFillBuffer(_vulkanDevice, meshData.Indices.data(),
-                            sizeof(meshData.Indices[0]) * meshData.IndexCount,
+        CreateAndFillBuffer(_vulkanDevice, meshData.indices.data(),
+                            sizeof(meshData.indices[0]) * meshData.indexCount,
                             VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
                             meshRenderData.indexBuffer);
 
@@ -191,7 +191,7 @@ namespace IC {
                 VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
                 meshRenderData.mvpBuffers[i].buffer, meshRenderData.mvpBuffers[i].memory);
 
-            CreateAndFillBuffer(_vulkanDevice, &materialData.Constants, sizeof(MaterialConstants),
+            CreateAndFillBuffer(_vulkanDevice, &materialData.constants, sizeof(MaterialConstants),
                                 VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
                                 VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
                                 meshRenderData.constantsBuffers[i]);

--- a/src/vulkan/vulkan_renderer.cpp
+++ b/src/vulkan/vulkan_renderer.cpp
@@ -1,3 +1,5 @@
+#include <ic_log.h>
+
 #include "vulkan_initializers.h"
 #include "vulkan_renderer.h"
 #include "vulkan_util.h"
@@ -47,18 +49,20 @@ namespace IC
 
         if (result != VK_SUCCESS && result != VK_SUBOPTIMAL_KHR)
         {
-            throw std::runtime_error("failed to acquire swap chain image");
+            IC_CORE_ERROR("Failed to acquire swap chain image.");
+            throw std::runtime_error("Failed to acquire swap chain image.");
         }
 
         _swapChain.WaitForFrameFence(&imageIndex);
 
         vkResetCommandBuffer(_cBuffers[imageIndex], 0);
 
-        VkCommandBufferBeginInfo beginInfo = Init::CommandBufferBeginInfo();
+        VkCommandBufferBeginInfo beginInfo = CommandBufferBeginInfo();
 
         if (vkBeginCommandBuffer(_cBuffers[imageIndex], &beginInfo) != VK_SUCCESS)
         {
-            throw std::runtime_error("failed to begin recording command buffer");
+            IC_CORE_ERROR("Failed to begin recording command buffer.");
+            throw std::runtime_error("Failed to begin recording command buffer.");
         }
 
         VkRenderingAttachmentInfo colorAttachment = {.sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO};
@@ -133,13 +137,15 @@ namespace IC
 
         if (vkEndCommandBuffer(_cBuffers[imageIndex]) != VK_SUCCESS)
         {
-            throw std::runtime_error("failed to record command buffer");
+            IC_CORE_ERROR("Failed to record command buffer.");
+            throw std::runtime_error("Failed to record command buffer.");
         }
 
         result = _swapChain.SubmitCommandBuffers(&_cBuffers[imageIndex], &imageIndex);
         if (result != VK_SUCCESS)
         {
-            throw std::runtime_error("failed to present swap chain image");
+            IC_CORE_ERROR("Failed to present swap chain image.");
+            throw std::runtime_error("Failed to present swap chain image.");
         }
     }
 

--- a/src/vulkan/vulkan_renderer.cpp
+++ b/src/vulkan/vulkan_renderer.cpp
@@ -15,9 +15,8 @@ namespace IC {
     }
 
     VulkanRenderer::VulkanRenderer(RendererConfig &config)
-        : Renderer{config},
-          _swapChain{_vulkanDevice,
-                     {static_cast<uint32_t>(config.width), static_cast<uint32_t>(config.height)}} {
+        : Renderer{config}, _swapChain{_vulkanDevice,
+                                       {static_cast<uint32_t>(config.width), static_cast<uint32_t>(config.height)}} {
         CreateCommandBuffers();
         InitDescriptorAllocator();
     }
@@ -61,16 +60,14 @@ namespace IC {
             throw std::runtime_error("Failed to begin recording command buffer.");
         }
 
-        VkRenderingAttachmentInfo colorAttachment = {
-            .sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO};
+        VkRenderingAttachmentInfo colorAttachment = {.sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO};
         colorAttachment.imageView = _swapChain.GetImageView(imageIndex);
         colorAttachment.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
         colorAttachment.clearValue = {0.1f, 0.1f, 0.1f, 1.0f};
         colorAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
         colorAttachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
 
-        VkRenderingAttachmentInfo depthAttachment{.sType =
-                                                      VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO};
+        VkRenderingAttachmentInfo depthAttachment{.sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO};
         depthAttachment.imageView = _swapChain.GetDepthImageView(imageIndex);
         depthAttachment.imageLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
         depthAttachment.clearValue.depthStencil = {1.0f, 0};
@@ -114,23 +111,19 @@ namespace IC {
 
         for (MeshRenderData data : _renderData) {
             // bind pipeline todo: only bind if different
-            vkCmdBindPipeline(_cBuffers[imageIndex], VK_PIPELINE_BIND_POINT_GRAPHICS,
-                              data.renderPipeline->pipeline);
+            vkCmdBindPipeline(_cBuffers[imageIndex], VK_PIPELINE_BIND_POINT_GRAPHICS, data.renderPipeline->pipeline);
 
             MVPObject ubo{};
             // hard coded for now
-            ubo.model = glm::rotate(glm::scale(glm::mat4(1.0f), {0.2f, 0.2f, 0.2f}), rotation,
-                                    {0.0f, 0.0f, 1.0f});
-            ubo.view = glm::lookAt(glm::vec3(2.0f, 2.0f, 2.0f), glm::vec3(0.0f, 0.0f, 0.0f),
-                                   glm::vec3(0.0f, 0.0f, 1.0f));
-            ubo.proj = glm::perspective(glm::radians(45.0f),
-                                        (float)_swapChain.GetSwapChainExtent().width /
-                                            _swapChain.GetSwapChainExtent().height,
-                                        0.1f, 10.0f);
+            ubo.model = glm::rotate(glm::scale(glm::mat4(1.0f), {0.2f, 0.2f, 0.2f}), rotation, {0.0f, 0.0f, 1.0f});
+            ubo.view =
+                glm::lookAt(glm::vec3(2.0f, 2.0f, 2.0f), glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(0.0f, 0.0f, 1.0f));
+            ubo.proj = glm::perspective(
+                glm::radians(45.0f),
+                (float)_swapChain.GetSwapChainExtent().width / _swapChain.GetSwapChainExtent().height, 0.1f, 10.0f);
 
             data.UpdateMvpBuffer(ubo, _swapChain.GetCurrentFrame());
-            data.Bind(_cBuffers[imageIndex], data.renderPipeline->layout,
-                      _swapChain.GetCurrentFrame());
+            data.Bind(_cBuffers[imageIndex], data.renderPipeline->layout, _swapChain.GetCurrentFrame());
             data.Draw(_cBuffers[imageIndex]);
         }
 
@@ -138,8 +131,7 @@ namespace IC {
         ((PFN_vkCmdEndRenderingKHR)function2)(_cBuffers[imageIndex]);
 
         TransitionImageLayout(_cBuffers[imageIndex], _swapChain.GetImage(imageIndex),
-                              _swapChain.GetSwapChainImageFormat(),
-                              VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+                              _swapChain.GetSwapChainImageFormat(), VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
                               VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
 
         if (vkEndCommandBuffer(_cBuffers[imageIndex]) != VK_SUCCESS) {
@@ -156,12 +148,12 @@ namespace IC {
 
     void VulkanRenderer::InitDescriptorAllocator() {
         std::vector<VkDescriptorPoolSize> poolSizes{};
-        poolSizes.push_back({VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
-                             static_cast<uint32_t>(SwapChain::MAX_FRAMES_IN_FLIGHT)});
-        poolSizes.push_back({VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
-                             static_cast<uint32_t>(SwapChain::MAX_FRAMES_IN_FLIGHT)});
-        poolSizes.push_back({VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-                             static_cast<uint32_t>(SwapChain::MAX_FRAMES_IN_FLIGHT)});
+        poolSizes.push_back(
+            {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, static_cast<uint32_t>(SwapChain::MAX_FRAMES_IN_FLIGHT)});
+        poolSizes.push_back(
+            {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, static_cast<uint32_t>(SwapChain::MAX_FRAMES_IN_FLIGHT)});
+        poolSizes.push_back(
+            {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, static_cast<uint32_t>(SwapChain::MAX_FRAMES_IN_FLIGHT)});
 
         _descriptorAllocator.CreateDescriptorPool(_vulkanDevice.Device(), poolSizes, 100);
     }
@@ -170,49 +162,43 @@ namespace IC {
     void VulkanRenderer::AddMesh(Mesh &meshData, Material &materialData) {
         MeshRenderData meshRenderData{.meshData = meshData, .materialData = materialData};
 
-        meshRenderData.renderPipeline = _pipelineManager.FindOrCreateSuitablePipeline(
-            _vulkanDevice.Device(), _swapChain, materialData);
+        meshRenderData.renderPipeline =
+            _pipelineManager.FindOrCreateSuitablePipeline(_vulkanDevice.Device(), _swapChain, materialData);
 
         // buffers
         CreateAndFillBuffer(_vulkanDevice, meshData.vertices.data(),
-                            sizeof(meshData.vertices[0]) * meshData.vertexCount,
-                            VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-                            meshRenderData.vertexBuffer);
-        CreateAndFillBuffer(_vulkanDevice, meshData.indices.data(),
-                            sizeof(meshData.indices[0]) * meshData.indexCount,
+                            sizeof(meshData.vertices[0]) * meshData.vertexCount, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
+                            VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, meshRenderData.vertexBuffer);
+        CreateAndFillBuffer(_vulkanDevice, meshData.indices.data(), sizeof(meshData.indices[0]) * meshData.indexCount,
                             VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
                             meshRenderData.indexBuffer);
 
         meshRenderData.mvpBuffers.resize(SwapChain::MAX_FRAMES_IN_FLIGHT);
         meshRenderData.constantsBuffers.resize(SwapChain::MAX_FRAMES_IN_FLIGHT);
         for (size_t i = 0; i < SwapChain::MAX_FRAMES_IN_FLIGHT; i++) {
-            _vulkanDevice.CreateBuffer(
-                sizeof(MVPObject), VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
-                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-                meshRenderData.mvpBuffers[i].buffer, meshRenderData.mvpBuffers[i].memory);
+            _vulkanDevice.CreateBuffer(sizeof(MVPObject), VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
+                                       VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+                                       meshRenderData.mvpBuffers[i].buffer, meshRenderData.mvpBuffers[i].memory);
 
             CreateAndFillBuffer(_vulkanDevice, &materialData.constants, sizeof(MaterialConstants),
-                                VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
-                                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
+                                VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
                                 meshRenderData.constantsBuffers[i]);
 
-            vkMapMemory(_vulkanDevice.Device(), meshRenderData.mvpBuffers[i].memory, 0,
-                        sizeof(MVPObject), 0, &meshRenderData.mvpBuffers[i].mapped_memory);
-            vkMapMemory(_vulkanDevice.Device(), meshRenderData.constantsBuffers[i].memory, 0,
-                        sizeof(MaterialConstants), 0,
-                        &meshRenderData.constantsBuffers[i].mapped_memory);
+            vkMapMemory(_vulkanDevice.Device(), meshRenderData.mvpBuffers[i].memory, 0, sizeof(MVPObject), 0,
+                        &meshRenderData.mvpBuffers[i].mapped_memory);
+            vkMapMemory(_vulkanDevice.Device(), meshRenderData.constantsBuffers[i].memory, 0, sizeof(MaterialConstants),
+                        0, &meshRenderData.constantsBuffers[i].mapped_memory);
         }
 
         // write descriptor sets
         _descriptorAllocator.AllocateDescriptorSets(
-            _vulkanDevice.Device(), meshRenderData.renderPipeline->descriptorSetLayout,
-            meshRenderData.descriptorSets);
+            _vulkanDevice.Device(), meshRenderData.renderPipeline->descriptorSetLayout, meshRenderData.descriptorSets);
         DescriptorWriter writer{};
         for (size_t i = 0; i < SwapChain::MAX_FRAMES_IN_FLIGHT; i++) {
             writer.WriteBuffer(0, meshRenderData.mvpBuffers[i].buffer, sizeof(MVPObject), 0,
                                VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
-            writer.WriteBuffer(1, meshRenderData.constantsBuffers[i].buffer,
-                               sizeof(MaterialConstants), 0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
+            writer.WriteBuffer(1, meshRenderData.constantsBuffers[i].buffer, sizeof(MaterialConstants), 0,
+                               VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
 
             writer.UpdateSet(_vulkanDevice.Device(), meshRenderData.descriptorSets[i]);
         }

--- a/src/vulkan/vulkan_renderer.h
+++ b/src/vulkan/vulkan_renderer.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include "ic_renderer.h"
 
 #include "descriptors.h"
@@ -6,10 +7,8 @@
 #include "swap_chain.h"
 #include "vulkan_types.h"
 
-namespace IC
-{
-    class VulkanRenderer : public Renderer
-    {
+namespace IC {
+    class VulkanRenderer : public Renderer {
     public:
         VulkanRenderer(RendererConfig &config);
         ~VulkanRenderer();
@@ -29,4 +28,4 @@ namespace IC
         std::vector<MeshRenderData> _renderData;
         std::vector<VkCommandBuffer> _cBuffers;
     };
-}
+} // namespace IC

--- a/src/vulkan/vulkan_renderer.h
+++ b/src/vulkan/vulkan_renderer.h
@@ -1,12 +1,12 @@
 #pragma once
-#include <ic_renderer.h>
+#include "ic_renderer.h"
 
 #include "descriptors.h"
 #include "pipelines.h"
 #include "swap_chain.h"
 #include "vulkan_types.h"
 
-namespace IC::Renderer
+namespace IC
 {
     class VulkanRenderer : public Renderer
     {
@@ -20,11 +20,6 @@ namespace IC::Renderer
     private:
         void CreateCommandBuffers();
         void InitDescriptorAllocator();
-
-        static Renderer *MakeVulkan(RendererConfig rendererConfig)
-        {
-            return new VulkanRenderer(rendererConfig);
-        }
 
         VulkanDevice _vulkanDevice{Window};
         SwapChain _swapChain;

--- a/src/vulkan/vulkan_renderer.h
+++ b/src/vulkan/vulkan_renderer.h
@@ -20,7 +20,7 @@ namespace IC {
         void CreateCommandBuffers();
         void InitDescriptorAllocator();
 
-        VulkanDevice _vulkanDevice{Window};
+        VulkanDevice _vulkanDevice{window};
         SwapChain _swapChain;
         PipelineManager _pipelineManager{};
         DescriptorAllocator _descriptorAllocator{};

--- a/src/vulkan/vulkan_types.h
+++ b/src/vulkan/vulkan_types.h
@@ -6,6 +6,7 @@
 #include <glm/vec4.hpp>
 
 #include <ic_graphics.h>
+#include <ic_log.h>
 #include <vulkan/vk_enum_string_helper.h>
 
 #include <array>
@@ -20,6 +21,7 @@
         VkResult err = x;                                   \
         if (err)                                            \
         {                                                   \
+            IC_CORE_ERROR("{0}", string_VkResult(err));     \
             throw std::runtime_error(string_VkResult(err)); \
             abort();                                        \
         }                                                   \

--- a/src/vulkan/vulkan_types.h
+++ b/src/vulkan/vulkan_types.h
@@ -15,14 +15,14 @@
 #include <stdexcept>
 #include <vector>
 
-#define VK_CHECK(x)                                                                                \
-    do {                                                                                           \
-        VkResult err = x;                                                                          \
-        if (err) {                                                                                 \
-            IC_CORE_ERROR("{0}", string_VkResult(err));                                            \
-            throw std::runtime_error(string_VkResult(err));                                        \
-            abort();                                                                               \
-        }                                                                                          \
+#define VK_CHECK(x)                                                                                                    \
+    do {                                                                                                               \
+        VkResult err = x;                                                                                              \
+        if (err) {                                                                                                     \
+            IC_CORE_ERROR("{0}", string_VkResult(err));                                                                \
+            throw std::runtime_error(string_VkResult(err));                                                            \
+            abort();                                                                                                   \
+        }                                                                                                              \
     } while (0)
 
 namespace IC {
@@ -75,9 +75,7 @@ namespace IC {
                                     &descriptorSets[currentFrame], 0, nullptr);
         }
 
-        void Draw(VkCommandBuffer cBuffer) {
-            vkCmdDrawIndexed(cBuffer, meshData.indexCount, 1, 0, 0, 0);
-        }
+        void Draw(VkCommandBuffer cBuffer) { vkCmdDrawIndexed(cBuffer, meshData.indexCount, 1, 0, 0, 0); }
 
         void UpdateMvpBuffer(MVPObject uniformBuffer, uint32_t currentImage) {
             memcpy(mvpBuffers[currentImage].mapped_memory, &uniformBuffer, sizeof(uniformBuffer));

--- a/src/vulkan/vulkan_types.h
+++ b/src/vulkan/vulkan_types.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#define GLM_FORCE_RADIANS
-#define GLM_FORCE_DEPTH_ZERO_TO_ONE
-#include <glm/mat4x4.hpp>
-#include <glm/vec4.hpp>
-
 #include <ic_graphics.h>
 #include <ic_log.h>
+
+#define GLM_FORCE_DEPTH_ZERO_TO_ONE
+#define GLM_FORCE_RADIANS
+#include <glm/mat4x4.hpp>
+#include <glm/vec4.hpp>
 #include <vulkan/vk_enum_string_helper.h>
 
 #include <array>
@@ -15,57 +15,48 @@
 #include <stdexcept>
 #include <vector>
 
-#define VK_CHECK(x)                                         \
-    do                                                      \
-    {                                                       \
-        VkResult err = x;                                   \
-        if (err)                                            \
-        {                                                   \
-            IC_CORE_ERROR("{0}", string_VkResult(err));     \
-            throw std::runtime_error(string_VkResult(err)); \
-            abort();                                        \
-        }                                                   \
+#define VK_CHECK(x)                                                                                \
+    do {                                                                                           \
+        VkResult err = x;                                                                          \
+        if (err) {                                                                                 \
+            IC_CORE_ERROR("{0}", string_VkResult(err));                                            \
+            throw std::runtime_error(string_VkResult(err));                                        \
+            abort();                                                                               \
+        }                                                                                          \
     } while (0)
 
-namespace IC
-{
-    struct AllocatedBuffer
-    {
+namespace IC {
+    struct AllocatedBuffer {
         VkBuffer buffer;
         VkDeviceMemory memory;
         void *mapped_memory;
     };
 
-    struct AllocatedImage
-    {
+    struct AllocatedImage {
         VkImage image;
         VkImageView view;
         VkDeviceMemory memory;
     };
 
-    struct MVPObject
-    {
+    struct MVPObject {
         glm::mat4 model;
         glm::mat4 view;
         glm::mat4 proj;
     };
 
-    struct Pipeline
-    {
+    struct Pipeline {
         VkPipeline pipeline;
         VkPipelineLayout layout;
         std::vector<VkShaderModule> shaderModules;
         VkDescriptorSetLayout descriptorSetLayout;
         bool transparent = false;
 
-        bool operator<(const Pipeline &other) const
-        {
+        bool operator<(const Pipeline &other) const {
             return pipeline < other.pipeline && transparent <= other.transparent;
         }
     };
 
-    struct MeshRenderData
-    {
+    struct MeshRenderData {
         Mesh &meshData;
         Material &materialData;
         std::shared_ptr<Pipeline> renderPipeline;
@@ -75,28 +66,25 @@ namespace IC
         std::vector<AllocatedBuffer> mvpBuffers;
         std::vector<AllocatedBuffer> constantsBuffers;
 
-        void Bind(VkCommandBuffer cBuffer, VkPipelineLayout pipelineLayout, size_t currentFrame)
-        {
+        void Bind(VkCommandBuffer cBuffer, VkPipelineLayout pipelineLayout, size_t currentFrame) {
             VkBuffer vertexBuffers[] = {vertexBuffer.buffer};
             VkDeviceSize offsets[] = {0};
             vkCmdBindVertexBuffers(cBuffer, 0, 1, vertexBuffers, offsets);
             vkCmdBindIndexBuffer(cBuffer, indexBuffer.buffer, 0, VK_INDEX_TYPE_UINT32);
-            vkCmdBindDescriptorSets(cBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelineLayout, 0, 1, &descriptorSets[currentFrame], 0, nullptr);
+            vkCmdBindDescriptorSets(cBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelineLayout, 0, 1,
+                                    &descriptorSets[currentFrame], 0, nullptr);
         }
 
-        void Draw(VkCommandBuffer cBuffer)
-        {
+        void Draw(VkCommandBuffer cBuffer) {
             vkCmdDrawIndexed(cBuffer, meshData.IndexCount, 1, 0, 0, 0);
         }
 
-        void UpdateMvpBuffer(MVPObject uniformBuffer, uint32_t currentImage)
-        {
+        void UpdateMvpBuffer(MVPObject uniformBuffer, uint32_t currentImage) {
             memcpy(mvpBuffers[currentImage].mapped_memory, &uniformBuffer, sizeof(uniformBuffer));
         }
     };
 
-    static VkVertexInputBindingDescription GetVertexBindingDescription()
-    {
+    static VkVertexInputBindingDescription GetVertexBindingDescription() {
         VkVertexInputBindingDescription bindingDescription{};
         bindingDescription.binding = 0;
         bindingDescription.stride = sizeof(VertexData);
@@ -104,8 +92,7 @@ namespace IC
         return bindingDescription;
     }
 
-    static std::array<VkVertexInputAttributeDescription, 3> GetVertexAttributeDescriptions()
-    {
+    static std::array<VkVertexInputAttributeDescription, 3> GetVertexAttributeDescriptions() {
         std::array<VkVertexInputAttributeDescription, 3> attributeDescriptions{};
         attributeDescriptions[0].binding = 0;
         attributeDescriptions[0].location = 0;
@@ -123,4 +110,4 @@ namespace IC
         attributeDescriptions[2].offset = offsetof(VertexData, TexCoord);
         return attributeDescriptions;
     }
-}
+} // namespace IC

--- a/src/vulkan/vulkan_types.h
+++ b/src/vulkan/vulkan_types.h
@@ -25,7 +25,7 @@
         }                                                   \
     } while (0)
 
-namespace IC::Renderer
+namespace IC
 {
     struct AllocatedBuffer
     {

--- a/src/vulkan/vulkan_types.h
+++ b/src/vulkan/vulkan_types.h
@@ -76,7 +76,7 @@ namespace IC {
         }
 
         void Draw(VkCommandBuffer cBuffer) {
-            vkCmdDrawIndexed(cBuffer, meshData.IndexCount, 1, 0, 0, 0);
+            vkCmdDrawIndexed(cBuffer, meshData.indexCount, 1, 0, 0, 0);
         }
 
         void UpdateMvpBuffer(MVPObject uniformBuffer, uint32_t currentImage) {
@@ -97,17 +97,17 @@ namespace IC {
         attributeDescriptions[0].binding = 0;
         attributeDescriptions[0].location = 0;
         attributeDescriptions[0].format = VK_FORMAT_R32G32B32_SFLOAT;
-        attributeDescriptions[0].offset = offsetof(VertexData, Pos);
+        attributeDescriptions[0].offset = offsetof(VertexData, pos);
 
         attributeDescriptions[1].binding = 0;
         attributeDescriptions[1].location = 1;
         attributeDescriptions[1].format = VK_FORMAT_R32G32B32_SFLOAT;
-        attributeDescriptions[1].offset = offsetof(VertexData, Color);
+        attributeDescriptions[1].offset = offsetof(VertexData, color);
 
         attributeDescriptions[2].binding = 0;
         attributeDescriptions[2].location = 2;
         attributeDescriptions[2].format = VK_FORMAT_R32G32_SFLOAT;
-        attributeDescriptions[2].offset = offsetof(VertexData, TexCoord);
+        attributeDescriptions[2].offset = offsetof(VertexData, texCoord);
         return attributeDescriptions;
     }
 } // namespace IC

--- a/src/vulkan/vulkan_util.cpp
+++ b/src/vulkan/vulkan_util.cpp
@@ -4,7 +4,7 @@
 
 #include <cstring>
 
-namespace IC::Renderer::Util
+namespace IC
 {
     void CreateAndFillBuffer(VulkanDevice &device, const void *srcData, VkDeviceSize bufferSize, VkBufferUsageFlags bufferUsageFlags,
                              VkMemoryPropertyFlags memoryPropertyFlags, AllocatedBuffer &allocatedBuffer)

--- a/src/vulkan/vulkan_util.cpp
+++ b/src/vulkan/vulkan_util.cpp
@@ -6,23 +6,21 @@
 
 namespace IC {
     void CreateAndFillBuffer(VulkanDevice &device, const void *srcData, VkDeviceSize bufferSize,
-                             VkBufferUsageFlags bufferUsageFlags,
-                             VkMemoryPropertyFlags memoryPropertyFlags,
+                             VkBufferUsageFlags bufferUsageFlags, VkMemoryPropertyFlags memoryPropertyFlags,
                              AllocatedBuffer &allocatedBuffer) {
         VkBuffer stagingBuffer;
         VkDeviceMemory stagingBufferMemory;
 
         device.CreateBuffer(bufferSize, VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
-                            VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
-                                VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-                            stagingBuffer, stagingBufferMemory);
+                            VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, stagingBuffer,
+                            stagingBufferMemory);
         void *data;
         vkMapMemory(device.Device(), stagingBufferMemory, 0, bufferSize, 0, &data);
         memcpy(data, srcData, (size_t)bufferSize);
         vkUnmapMemory(device.Device(), stagingBufferMemory);
 
-        device.CreateBuffer(bufferSize, VK_BUFFER_USAGE_TRANSFER_DST_BIT | bufferUsageFlags,
-                            memoryPropertyFlags, allocatedBuffer.buffer, allocatedBuffer.memory);
+        device.CreateBuffer(bufferSize, VK_BUFFER_USAGE_TRANSFER_DST_BIT | bufferUsageFlags, memoryPropertyFlags,
+                            allocatedBuffer.buffer, allocatedBuffer.memory);
 
         device.CopyBuffer(stagingBuffer, allocatedBuffer.buffer, bufferSize);
 
@@ -41,8 +39,8 @@ namespace IC {
         }
     }
 
-    void CopyImageToImage(VkCommandBuffer commandBuffer, VkImage source, VkImage destination,
-                          VkExtent2D srcSize, VkExtent2D dstSize) {
+    void CopyImageToImage(VkCommandBuffer commandBuffer, VkImage source, VkImage destination, VkExtent2D srcSize,
+                          VkExtent2D dstSize) {
         VkImageBlit2 blitRegion{.sType = VK_STRUCTURE_TYPE_IMAGE_BLIT_2, .pNext = nullptr};
 
         blitRegion.srcOffsets[1].x = srcSize.width;
@@ -75,8 +73,8 @@ namespace IC {
         vkCmdBlitImage2(commandBuffer, &blitInfo);
     }
 
-    void TransitionImageLayout(VkCommandBuffer commandBuffer, VkImage image, VkFormat format,
-                               VkImageLayout oldLayout, VkImageLayout newLayout) {
+    void TransitionImageLayout(VkCommandBuffer commandBuffer, VkImage image, VkFormat format, VkImageLayout oldLayout,
+                               VkImageLayout newLayout) {
         VkImageMemoryBarrier barrier{};
         barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
         barrier.oldLayout = oldLayout;
@@ -95,8 +93,7 @@ namespace IC {
         VkPipelineStageFlags sourceStage;
         VkPipelineStageFlags destinationStage;
 
-        if (oldLayout == VK_IMAGE_LAYOUT_UNDEFINED &&
-            newLayout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL) {
+        if (oldLayout == VK_IMAGE_LAYOUT_UNDEFINED && newLayout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL) {
             barrier.srcAccessMask = 0;
             barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
 
@@ -117,8 +114,7 @@ namespace IC {
             destinationStage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
         }
 
-        vkCmdPipelineBarrier(commandBuffer, sourceStage, destinationStage, 0, 0, nullptr, 0,
-                             nullptr, 1, &barrier);
+        vkCmdPipelineBarrier(commandBuffer, sourceStage, destinationStage, 0, 0, nullptr, 0, nullptr, 1, &barrier);
     }
     // todo
     /*

--- a/src/vulkan/vulkan_util.cpp
+++ b/src/vulkan/vulkan_util.cpp
@@ -140,7 +140,8 @@ namespace IC
 
         if (!pixels)
         {
-            throw std::runtime_error("failed to load texture image");
+            IC_CORE_ERROR("Failed to load texture image.");
+            throw std::runtime_error("Failed to load texture image.");
         }
 
         VkBuffer stagingBuffer;

--- a/src/vulkan/vulkan_util.cpp
+++ b/src/vulkan/vulkan_util.cpp
@@ -4,11 +4,11 @@
 
 #include <cstring>
 
-namespace IC
-{
-    void CreateAndFillBuffer(VulkanDevice &device, const void *srcData, VkDeviceSize bufferSize, VkBufferUsageFlags bufferUsageFlags,
-                             VkMemoryPropertyFlags memoryPropertyFlags, AllocatedBuffer &allocatedBuffer)
-    {
+namespace IC {
+    void CreateAndFillBuffer(VulkanDevice &device, const void *srcData, VkDeviceSize bufferSize,
+                             VkBufferUsageFlags bufferUsageFlags,
+                             VkMemoryPropertyFlags memoryPropertyFlags,
+                             AllocatedBuffer &allocatedBuffer) {
         VkBuffer stagingBuffer;
         VkDeviceMemory stagingBufferMemory;
 
@@ -21,8 +21,7 @@ namespace IC
         memcpy(data, srcData, (size_t)bufferSize);
         vkUnmapMemory(device.Device(), stagingBufferMemory);
 
-        device.CreateBuffer(bufferSize,
-                            VK_BUFFER_USAGE_TRANSFER_DST_BIT | bufferUsageFlags,
+        device.CreateBuffer(bufferSize, VK_BUFFER_USAGE_TRANSFER_DST_BIT | bufferUsageFlags,
                             memoryPropertyFlags, allocatedBuffer.buffer, allocatedBuffer.memory);
 
         device.CopyBuffer(stagingBuffer, allocatedBuffer.buffer, bufferSize);
@@ -31,10 +30,8 @@ namespace IC
         vkFreeMemory(device.Device(), stagingBufferMemory, nullptr);
     }
 
-    VkDescriptorType MaterialInputTypeMapping(MaterialInputType inputType)
-    {
-        switch (inputType)
-        {
+    VkDescriptorType MaterialInputTypeMapping(MaterialInputType inputType) {
+        switch (inputType) {
         case MaterialInputType::Color:
             return VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
         case MaterialInputType::Texture:
@@ -45,8 +42,7 @@ namespace IC
     }
 
     void CopyImageToImage(VkCommandBuffer commandBuffer, VkImage source, VkImage destination,
-                          VkExtent2D srcSize, VkExtent2D dstSize)
-    {
+                          VkExtent2D srcSize, VkExtent2D dstSize) {
         VkImageBlit2 blitRegion{.sType = VK_STRUCTURE_TYPE_IMAGE_BLIT_2, .pNext = nullptr};
 
         blitRegion.srcOffsets[1].x = srcSize.width;
@@ -80,8 +76,7 @@ namespace IC
     }
 
     void TransitionImageLayout(VkCommandBuffer commandBuffer, VkImage image, VkFormat format,
-                               VkImageLayout oldLayout, VkImageLayout newLayout)
-    {
+                               VkImageLayout oldLayout, VkImageLayout newLayout) {
         VkImageMemoryBarrier barrier{};
         barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
         barrier.oldLayout = oldLayout;
@@ -101,25 +96,20 @@ namespace IC
         VkPipelineStageFlags destinationStage;
 
         if (oldLayout == VK_IMAGE_LAYOUT_UNDEFINED &&
-            newLayout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL)
-        {
+            newLayout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL) {
             barrier.srcAccessMask = 0;
             barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
 
             sourceStage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
             destinationStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
-        }
-        else if (oldLayout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL &&
-                 newLayout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
-        {
+        } else if (oldLayout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL &&
+                   newLayout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL) {
             barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
             barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
 
             sourceStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
             destinationStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
-        }
-        else
-        {
+        } else {
             barrier.srcAccessMask = VK_ACCESS_MEMORY_WRITE_BIT;
             barrier.dstAccessMask = VK_ACCESS_MEMORY_WRITE_BIT | VK_ACCESS_MEMORY_READ_BIT;
 
@@ -127,16 +117,16 @@ namespace IC
             destinationStage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
         }
 
-        vkCmdPipelineBarrier(commandBuffer, sourceStage, destinationStage, 0, 0, nullptr, 0, nullptr, 1,
-                             &barrier);
+        vkCmdPipelineBarrier(commandBuffer, sourceStage, destinationStage, 0, 0, nullptr, 0,
+                             nullptr, 1, &barrier);
     }
     // todo
     /*
     void LoadTextureImage(VulkanDevice &device, std::string texturePath, AllocatedImage &outImage)
     {
         int texWidth, texHeight, texChannels;
-        stbi_uc *pixels = stbi_load(texturePath.c_str(), &texWidth, &texHeight, &texChannels, STBI_rgb_alpha);
-        VkDeviceSize imageSize = texWidth * texHeight * 4;
+        stbi_uc *pixels = stbi_load(texturePath.c_str(), &texWidth, &texHeight, &texChannels,
+    STBI_rgb_alpha); VkDeviceSize imageSize = texWidth * texHeight * 4;
 
         if (!pixels)
         {
@@ -179,4 +169,4 @@ namespace IC
         vkFreeMemory(device.Device(), stagingBufferMemory, nullptr);
     }
     */
-}
+} // namespace IC

--- a/src/vulkan/vulkan_util.h
+++ b/src/vulkan/vulkan_util.h
@@ -3,7 +3,7 @@
 #include "vulkan_types.h"
 #include "vulkan_device.h"
 
-namespace IC::Renderer::Util
+namespace IC
 {
     void CreateAndFillBuffer(VulkanDevice &device, const void *srcData, VkDeviceSize bufferSize, VkBufferUsageFlags bufferUsageFlags, VkMemoryPropertyFlags memoryPropertyFlags, AllocatedBuffer &allocatedBuffer);
     VkDescriptorType MaterialInputTypeMapping(MaterialInputType inputType);

--- a/src/vulkan/vulkan_util.h
+++ b/src/vulkan/vulkan_util.h
@@ -5,15 +5,14 @@
 
 namespace IC {
     void CreateAndFillBuffer(VulkanDevice &device, const void *srcData, VkDeviceSize bufferSize,
-                             VkBufferUsageFlags bufferUsageFlags,
-                             VkMemoryPropertyFlags memoryPropertyFlags,
+                             VkBufferUsageFlags bufferUsageFlags, VkMemoryPropertyFlags memoryPropertyFlags,
                              AllocatedBuffer &allocatedBuffer);
     VkDescriptorType MaterialInputTypeMapping(MaterialInputType inputType);
 
-    void CopyImageToImage(VkCommandBuffer commandBuffer, VkImage source, VkImage destination,
-                          VkExtent2D srcSize, VkExtent2D dstSize);
-    void TransitionImageLayout(VkCommandBuffer commandBuffer, VkImage image, VkFormat format,
-                               VkImageLayout oldLayout, VkImageLayout newLayout);
+    void CopyImageToImage(VkCommandBuffer commandBuffer, VkImage source, VkImage destination, VkExtent2D srcSize,
+                          VkExtent2D dstSize);
+    void TransitionImageLayout(VkCommandBuffer commandBuffer, VkImage image, VkFormat format, VkImageLayout oldLayout,
+                               VkImageLayout newLayout);
     // void LoadTextureImage(VulkanDevice &device, std::string texturePath, AllocatedImage
     // &outImage);
 } // namespace IC

--- a/src/vulkan/vulkan_util.h
+++ b/src/vulkan/vulkan_util.h
@@ -1,14 +1,19 @@
 #pragma once
 
-#include "vulkan_types.h"
 #include "vulkan_device.h"
+#include "vulkan_types.h"
 
-namespace IC
-{
-    void CreateAndFillBuffer(VulkanDevice &device, const void *srcData, VkDeviceSize bufferSize, VkBufferUsageFlags bufferUsageFlags, VkMemoryPropertyFlags memoryPropertyFlags, AllocatedBuffer &allocatedBuffer);
+namespace IC {
+    void CreateAndFillBuffer(VulkanDevice &device, const void *srcData, VkDeviceSize bufferSize,
+                             VkBufferUsageFlags bufferUsageFlags,
+                             VkMemoryPropertyFlags memoryPropertyFlags,
+                             AllocatedBuffer &allocatedBuffer);
     VkDescriptorType MaterialInputTypeMapping(MaterialInputType inputType);
 
-    void CopyImageToImage(VkCommandBuffer commandBuffer, VkImage source, VkImage destination, VkExtent2D srcSize, VkExtent2D dstSize);
-    void TransitionImageLayout(VkCommandBuffer commandBuffer, VkImage image, VkFormat format, VkImageLayout oldLayout, VkImageLayout newLayout);
-    // void LoadTextureImage(VulkanDevice &device, std::string texturePath, AllocatedImage &outImage);
-}
+    void CopyImageToImage(VkCommandBuffer commandBuffer, VkImage source, VkImage destination,
+                          VkExtent2D srcSize, VkExtent2D dstSize);
+    void TransitionImageLayout(VkCommandBuffer commandBuffer, VkImage image, VkFormat format,
+                               VkImageLayout oldLayout, VkImageLayout newLayout);
+    // void LoadTextureImage(VulkanDevice &device, std::string texturePath, AllocatedImage
+    // &outImage);
+} // namespace IC


### PR DESCRIPTION
- Removes `IC::Renderer`, `IC::Renderer::Init`, and `IC::Renderer::Utils` namespaces.
- Removes `ic_renderer.h` include from lib `ic.h` include, as this is looking to be something more "internal".
- Fixes `public`/`private` ordering in a few files.
- Clang format!
- Renames `ICCamera` to `Camera` (or `IC::Camera`), missed this yesterday.
- Updates `ic_app` to actually take advantage of `Renderer::MakeRenderer`, removing the hard dependency on Vulkan.
  - The current spots I'm leveraging `#ifdef IC_RENDERER_VULKAN`, kinda feel like hacks how it is, but good enough for now.
  - You now get a nice little error message if you don't provide a renderer. :)
- Updated `std::cout` logging to use `IC_CORE_INFO` for consistency.
- Paired each thrown `std::runtime_error` with a `IC_CORE_ERROR` so we can get it logged in the console, especially on Windows:
![image](https://github.com/Ice-Cavern-Games/ICEngine/assets/575593/6bb0c01f-c6b6-4420-a93c-bec9c3496782)
