### PR TITLE
Render stats

### DIFF
--- a/imgui.ini
+++ b/imgui.ini
@@ -15,3 +15,7 @@ Size=379,202
 Pos=1201,564
 Size=378,130
 
+[Window][Render Stats]
+Pos=12,11
+Size=304,86
+

--- a/src/ic_app.cpp
+++ b/src/ic_app.cpp
@@ -113,8 +113,8 @@ bool App::Run(const Config *c) {
     // appRendererApi->AddLight(light2);
     appRendererApi->AddDirectionalLight(dirLight);
     appRendererApi->AddMesh(mesh, material);
-    appRendererApi->AddImguiFunction(std::bind(&PointLight::ParameterGui, light.get()));
-    appRendererApi->AddImguiFunction(std::bind(&DirectionalLight::ParameterGui, dirLight.get()));
+    appRendererApi->AddImguiFunction("point light", std::bind(&PointLight::ParameterGui, light.get()));
+    appRendererApi->AddImguiFunction("directional light", std::bind(&DirectionalLight::ParameterGui, dirLight.get()));
 
     while (!glfwWindowShouldClose(window)) {
         glfwPollEvents();

--- a/src/ic_renderer.cpp
+++ b/src/ic_renderer.cpp
@@ -6,10 +6,12 @@
 
 namespace IC {
     Renderer::Renderer(const RendererConfig &config) : window(config.window) {
-        AddImguiFunction(std::bind(&Renderer::RenderStatsGUI, this));
+        AddImguiFunction(STATS_WINDOW_NAME, std::bind(&Renderer::RenderStatsGUI, this));
     }
 
-    Renderer::~Renderer() {}
+    Renderer::~Renderer() {
+        RemoveImguiFunction(STATS_WINDOW_NAME);
+    }
 
     Renderer *Renderer::MakeRenderer(const RendererConfig &rendererConfig) {
         switch (rendererConfig.rendererType) {
@@ -32,12 +34,11 @@ namespace IC {
         ImGui::End();
     }
 
-    void Renderer::AddImguiFunction(std::function<void()> function) {
-        imGuiFunctions.push_back(function);
+    void Renderer::AddImguiFunction(std::string windowName, std::function<void()> function) {
+        imGuiFunctions[windowName] = function;
     }
 
-    void Renderer::RemoveImguiFunction(std::function<void()> function) {
-        // unordered erase.
-        // std::erase(imGuiFunctions, function);
+    void Renderer::RemoveImguiFunction(std::string windowName) {
+        imGuiFunctions.erase(windowName);
     }
 } // namespace IC

--- a/src/ic_renderer.cpp
+++ b/src/ic_renderer.cpp
@@ -5,7 +5,9 @@
 #include <algorithm>
 
 namespace IC {
-    Renderer::Renderer(const RendererConfig &config) : window(config.window) {}
+    Renderer::Renderer(const RendererConfig &config) : window(config.window) {
+        AddImguiFunction(std::bind(&Renderer::RenderStatsGUI, this));
+    }
 
     Renderer::~Renderer() {}
 
@@ -20,6 +22,14 @@ namespace IC {
         default:
             return nullptr;
         }
+    }
+
+    void Renderer::RenderStatsGUI() {
+        ImGui::Begin("Render Stats");
+        ImGui::Text("frametime %f ms (%f FPS)", renderStats.frametime, 1 / (renderStats.frametime / 1000));
+        ImGui::Text("rendered tris: %d", renderStats.numTris);
+        ImGui::Text("draw calls: %d", renderStats.drawCalls);
+        ImGui::End();
     }
 
     void Renderer::AddImguiFunction(std::function<void()> function) {

--- a/src/ic_renderer.h
+++ b/src/ic_renderer.h
@@ -20,6 +20,12 @@ namespace IC {
         int height;
     };
 
+    struct RenderStats {
+        float frametime;
+        uint32_t numTris;
+        uint32_t drawCalls;
+    };
+
     class Renderer {
     public:
         Renderer(const RendererConfig &config);
@@ -38,6 +44,9 @@ namespace IC {
     protected:
         std::vector<std::function<void()>> imGuiFunctions;
         GLFWwindow *window;
+        RenderStats renderStats{};
+
+        void RenderStatsGUI();
 
     private:
         Renderer(const Renderer &) = delete;

--- a/src/ic_renderer.h
+++ b/src/ic_renderer.h
@@ -38,11 +38,11 @@ namespace IC {
         virtual void AddDirectionalLight(std::shared_ptr<DirectionalLight> light) = 0;
         virtual void DrawFrame() = 0;
 
-        void AddImguiFunction(std::function<void()> function);
-        void RemoveImguiFunction(std::function<void()> function);
+        void AddImguiFunction(std::string windowName, std::function<void()> function);
+        void RemoveImguiFunction(std::string windowName);
 
     protected:
-        std::vector<std::function<void()>> imGuiFunctions;
+        std::unordered_map<std::string, std::function<void()>> imGuiFunctions;
         GLFWwindow *window;
         RenderStats renderStats{};
 
@@ -51,5 +51,6 @@ namespace IC {
     private:
         Renderer(const Renderer &) = delete;
         Renderer &operator=(const Renderer &) = delete;
+        const std::string STATS_WINDOW_NAME = "render stats";
     };
 } // namespace IC

--- a/src/vulkan/vulkan_initializers.cpp
+++ b/src/vulkan/vulkan_initializers.cpp
@@ -123,7 +123,7 @@ namespace IC {
                                                       std::vector<std::shared_ptr<PointLight>> &pointLights,
                                                       glm::mat4 viewMat) {
         SceneLightDescriptors descriptors;
-        glm::vec3 directionalViewSpaceDirection = viewMat * glm::vec4(directionalLight->direction, 1.0f);
+        glm::vec3 directionalViewSpaceDirection = viewMat * glm::vec4(directionalLight->direction, 0.0f);
 
         DirectionalLightDescriptors directionalDescriptors{};
         directionalDescriptors.dir = directionalViewSpaceDirection;

--- a/src/vulkan/vulkan_renderer.cpp
+++ b/src/vulkan/vulkan_renderer.cpp
@@ -73,7 +73,7 @@ namespace IC {
     }
 
     void VulkanRenderer::DrawFrame() {
-        auto start = std::chrono::system_clock::now();
+        double start = glfwGetTime();
 
         ImGui_ImplVulkan_NewFrame();
         ImGui_ImplGlfw_NewFrame();
@@ -214,9 +214,9 @@ namespace IC {
 
         vkDeviceWaitIdle(_vulkanDevice.Device());
 
-        auto end = std::chrono::system_clock::now();
-        auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-        renderStats.frametime = elapsed.count() / 1000.0f;
+        double end = glfwGetTime();
+        double elapsed = end - start;
+        renderStats.frametime = elapsed * 1000.0f;
     }
 
     void VulkanRenderer::FramebufferResizeCallback(GLFWwindow *window, int width, int height) {

--- a/src/vulkan/vulkan_renderer.cpp
+++ b/src/vulkan/vulkan_renderer.cpp
@@ -78,8 +78,8 @@ namespace IC {
         ImGui_ImplVulkan_NewFrame();
         ImGui_ImplGlfw_NewFrame();
         ImGui::NewFrame();
-        for (auto function : imGuiFunctions) {
-            function();
+        for (auto keyValue : imGuiFunctions) {
+            keyValue.second();
         }
         ImGui::Render();
 

--- a/src/vulkan/vulkan_renderer.cpp
+++ b/src/vulkan/vulkan_renderer.cpp
@@ -73,6 +73,8 @@ namespace IC {
     }
 
     void VulkanRenderer::DrawFrame() {
+        auto start = std::chrono::system_clock::now();
+
         ImGui_ImplVulkan_NewFrame();
         ImGui_ImplGlfw_NewFrame();
         ImGui::NewFrame();
@@ -80,6 +82,10 @@ namespace IC {
             function();
         }
         ImGui::Render();
+
+        renderStats.drawCalls = 0;
+        renderStats.numTris = 0;
+        renderStats.frametime = 0.0f;
 
         static float rotation = 0.0f;
         rotation += 0.01f;
@@ -177,6 +183,8 @@ namespace IC {
 
             data.Bind(_cBuffers[imageIndex], data.renderPipeline->layout, _swapChain->GetCurrentFrame());
             data.Draw(_cBuffers[imageIndex]);
+            renderStats.drawCalls++;
+            renderStats.numTris += data.meshData.indexCount / 3;
         }
 
         VulkanEndRendering(_cBuffers[imageIndex]);
@@ -205,6 +213,10 @@ namespace IC {
         }
 
         vkDeviceWaitIdle(_vulkanDevice.Device());
+
+        auto end = std::chrono::system_clock::now();
+        auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+        renderStats.frametime = elapsed.count() / 1000.0f;
     }
 
     void VulkanRenderer::FramebufferResizeCallback(GLFWwindow *window, int width, int height) {


### PR DESCRIPTION
Tracks a few render stats (frametime/fps, tri count, draw calls)

also updates the view space multiplication for the directional light direction vector

![Screenshot from 2024-05-05 11-48-46](https://github.com/Ice-Cavern-Games/ICEngine/assets/11372356/e8341052-0548-40b5-9f8e-d8a0ac9fd0a0)

closes #17
