### PR TITLE
Events

### DIFF
--- a/include/events/ic_app_event.h
+++ b/include/events/ic_app_event.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "ic_event.h"
+
+namespace IC {
+    class AppRenderEvent : public Event {
+    public:
+        AppRenderEvent() = default;
+
+        EVENT_CLASS_TYPE(AppRender)
+        EVENT_CLASS_CATEGORY(EventCategoryApp)
+    };
+
+    class AppUpdateEvent : public Event {
+    public:
+        AppUpdateEvent() = default;
+
+        EVENT_CLASS_TYPE(AppUpdate)
+        EVENT_CLASS_CATEGORY(EventCategoryApp)
+    };
+
+    class WindowCloseEvent : public Event {
+    public:
+        WindowCloseEvent() = default;
+
+        EVENT_CLASS_TYPE(WindowClose)
+        EVENT_CLASS_CATEGORY(EventCategoryApp)
+    };
+
+    class WindowResizeEvent : public Event {
+    public:
+        WindowResizeEvent(unsigned int width, unsigned int height) : _width(width), _height(height) {}
+
+        unsigned int GetWidth() const { return _width; }
+        unsigned int GetHeight() const { return _height; }
+
+        EVENT_CLASS_TYPE(WindowResize)
+        EVENT_CLASS_CATEGORY(EventCategoryApp)
+
+    private:
+        unsigned int _width, _height;
+    };
+} // namespace IC

--- a/include/events/ic_event.h
+++ b/include/events/ic_event.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <functional>
+
+namespace IC {
+    enum class EventType {
+        None = 0,
+        // App events.
+        AppRender,
+        AppUpdate,
+        // Window events.
+        WindowClose,
+        WindowResize,
+    };
+
+    enum EventCategory {
+        EventCategoryNone = 0,
+        EventCategoryApp = 1 << 0,
+    };
+
+#define EVENT_CLASS_TYPE(type)                                                                                         \
+    static EventType GetStaticType() {                                                                                 \
+        return EventType::type;                                                                                        \
+    }                                                                                                                  \
+    virtual EventType GetEventType() const override {                                                                  \
+        return GetStaticType();                                                                                        \
+    }
+
+#define EVENT_CLASS_CATEGORY(category)                                                                                 \
+    virtual int GetCategoryFlags() const override {                                                                    \
+        return category;                                                                                               \
+    }
+
+    class Event {
+    public:
+        virtual ~Event() = default;
+
+        bool handled = false;
+
+        virtual EventType GetEventType() const = 0;
+        virtual int GetCategoryFlags() const = 0;
+
+        bool IsInCategory(EventCategory category) { return GetCategoryFlags() & category; }
+    };
+
+    class EventDispatcher {
+    public:
+        EventDispatcher(Event &event) : _event(event) {}
+
+        template <typename T, typename C> bool Dispatch(const C &callback) {
+            if (_event.GetEventType() == T::GetStaticType()) {
+                _event.handled |= callback(static_cast<T &>(_event));
+                return true;
+            }
+
+            return false;
+        }
+
+    private:
+        Event &_event;
+    };
+} // namespace IC

--- a/include/ic_app.h
+++ b/include/ic_app.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "events/ic_app_event.h"
+#include "events/ic_event.h"
 #include "ic_window.h"
 
 #include <string>
@@ -14,10 +16,15 @@ namespace IC {
         App(const Config &config);
         virtual ~App();
 
+        void OnEvent(Event &e);
+
         void Run();
 
     private:
         std::unique_ptr<Window> _window;
         bool _isRunning = true;
+
+        bool OnWindowClose(WindowCloseEvent &e);
+        bool OnWindowResize(WindowResizeEvent &e);
     };
 } // namespace IC

--- a/include/ic_material.h
+++ b/include/ic_material.h
@@ -10,9 +10,9 @@
 
 namespace IC {
     enum MaterialFlags {
-        None = 0,
-        Lit = 1 << 0,
-        Transparent = 1 << 1
+        MaterialFlagsNone = 0,
+        MaterialFlagsLit = 1 << 0,
+        MaterialFlagsTransparent = 1 << 1
     };
 
     enum class BindingType {

--- a/include/ic_window.h
+++ b/include/ic_window.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "events/ic_event.h"
+
 #include <functional>
 #include <string>
 
@@ -15,6 +17,8 @@ namespace IC {
 
     class Window {
     public:
+        using EventCallbackFn = std::function<void(Event &)>;
+
         virtual ~Window() {}
 
         virtual void OnUpdate() = 0;
@@ -24,6 +28,7 @@ namespace IC {
         virtual bool ShouldClose() const = 0;
 
         virtual void *GetNativeWindow() const = 0;
+        virtual void SetEventCallback(const EventCallbackFn &callback) = 0;
 
         static Window *Create(const WindowProps &props = WindowProps());
     };

--- a/src/ic_app.cpp
+++ b/src/ic_app.cpp
@@ -3,17 +3,43 @@
 #include <ic_log.h>
 
 namespace IC {
+
+#define BIND_EVENT_FN(x) std::bind(&App::x, this, std::placeholders::_1)
+
     App::App(const Config &config) {
         Log::Init();
+
         _window = std::unique_ptr<Window>(Window::Create(WindowProps(config.name)));
+        _window->SetEventCallback(BIND_EVENT_FN(OnEvent));
+
+        // @TODO: Init Renderer
     }
 
     App::~App() {}
 
     void App::Run() {
-        // @TODO: Switch to _isRunning
-        while (!_window->ShouldClose()) {
+        while (_isRunning) {
             _window->OnUpdate();
         }
+    }
+
+    void App::OnEvent(Event &e) {
+        EventDispatcher dispatcher(e);
+        dispatcher.Dispatch<WindowCloseEvent>(BIND_EVENT_FN(OnWindowClose));
+        dispatcher.Dispatch<WindowResizeEvent>(BIND_EVENT_FN(OnWindowResize));
+    }
+
+    bool App::OnWindowClose(WindowCloseEvent &e) {
+        _isRunning = false;
+
+        return true;
+    }
+
+    bool App::OnWindowResize(WindowResizeEvent &e) {
+        IC_CORE_TRACE("Window Resized: {0}, {1}", e.GetWidth(), e.GetHeight());
+
+        // @TODO: Renderer resize
+
+        return false;
     }
 } // namespace IC

--- a/src/platform/glfw_window.h
+++ b/src/platform/glfw_window.h
@@ -20,6 +20,7 @@ namespace IC {
         inline bool ShouldClose() const override { return glfwWindowShouldClose(_window); }
 
         inline virtual void *GetNativeWindow() const override { return _window; }
+        inline void SetEventCallback(const EventCallbackFn &callback) override { _data.eventCallback = callback; }
 
     private:
         virtual void Init(const WindowProps &props);
@@ -32,6 +33,8 @@ namespace IC {
         struct WindowData {
             std::string title;
             unsigned int width, height;
+
+            EventCallbackFn eventCallback;
         };
 
         WindowData _data;

--- a/src/vulkan/vulkan_initializers.cpp
+++ b/src/vulkan/vulkan_initializers.cpp
@@ -255,7 +255,7 @@ namespace IC {
         descriptorLayoutBuilder.Clear();
 
         // lit descriptors
-        if (materialData.Template().flags & MaterialFlags::Lit) {
+        if (materialData.Template().flags & MaterialFlags::MaterialFlagsLit) {
             descriptorLayoutBuilder.AddBinding(0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER); // scene light data
             descriptorSets.push_back(descriptorLayoutBuilder.Build(device, VK_SHADER_STAGE_FRAGMENT_BIT));
             descriptorLayoutBuilder.Clear();
@@ -300,8 +300,8 @@ namespace IC {
         pipelineBuilder.SetPolygonMode(VK_POLYGON_MODE_FILL);
         pipelineBuilder.SetCullMode(VK_CULL_MODE_BACK_BIT, VK_FRONT_FACE_CLOCKWISE);
         pipelineBuilder.SetMultisamplingNone();
-        materialData.Template().flags &MaterialFlags::Transparent ? pipelineBuilder.EnableBlending()
-                                                                  : pipelineBuilder.DisableBlending();
+        materialData.Template().flags &MaterialFlags::MaterialFlagsTransparent ? pipelineBuilder.EnableBlending()
+                                                                               : pipelineBuilder.DisableBlending();
         pipelineBuilder.EnableDepthTest();
         pipelineBuilder.SetColorAttachmentFormat(swapChain.GetSwapChainImageFormat());
         pipelineBuilder.SetDepthFormat(swapChain.GetSwapChainDepthFormat());

--- a/src/vulkan/vulkan_renderer.cpp
+++ b/src/vulkan/vulkan_renderer.cpp
@@ -29,13 +29,13 @@ namespace IC {
                   _swapChain->GetSwapChainImageFormat());
 
         // window resize callback
-        glfwSetWindowUserPointer(window, this);
-        glfwSetFramebufferSizeCallback(window, FramebufferResizeCallback);
+        // glfwSetWindowUserPointer(window, this);
+        // glfwSetFramebufferSizeCallback(window, FramebufferResizeCallback);
     }
 
     VulkanRenderer::~VulkanRenderer() {
-        glfwSetWindowUserPointer(window, nullptr);
-        glfwSetFramebufferSizeCallback(window, nullptr);
+        // glfwSetWindowUserPointer(window, nullptr);
+        // glfwSetFramebufferSizeCallback(window, nullptr);
 
         ImGui_ImplVulkan_Shutdown();
         _meshDescriptorAllocator.DestroyDescriptorPool(_vulkanDevice.Device());
@@ -176,7 +176,7 @@ namespace IC {
                                VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT, 0,
                                sizeof(TransformationPushConstants), &pushConstants);
 
-            if (data.materialData.Template().flags & MaterialFlags::Lit) {
+            if (data.materialData.Template().flags & MaterialFlags::MaterialFlagsLit) {
                 // update light data
                 SceneLightDescriptors descriptors =
                     CreateSceneLightDescriptors(_directionalLight, _pointLights, pushConstants.view);
@@ -281,7 +281,7 @@ namespace IC {
         writer.Clear();
 
         // scene data/lighting descriptors (set 1)
-        if (materialData->Template().flags & MaterialFlags::Lit) {
+        if (materialData->Template().flags & MaterialFlags::MaterialFlagsLit) {
             SceneLightDescriptors descriptors = CreateSceneLightDescriptors(
                 _directionalLight, _pointLights,
                 glm::lookAt(glm::vec3(2.0f, 2.0f, 2.0f), glm::vec3(0.0f), glm::vec3(0.0f, 0.0f, 1.0f)));
@@ -299,7 +299,7 @@ namespace IC {
         WriteMaterialDescriptors(_allocator, SwapChain::MAX_FRAMES_IN_FLIGHT, writer, *materialData, _textureManager,
                                  meshRenderData.materialBuffers);
         for (size_t i = 0; i < SwapChain::MAX_FRAMES_IN_FLIGHT; i++) {
-            int index = materialData->Template().flags & MaterialFlags::Lit ? 2 : 1;
+            int index = materialData->Template().flags & MaterialFlags::MaterialFlagsLit ? 2 : 1;
             writer.UpdateSet(_vulkanDevice.Device(), meshRenderData.descriptorSets[i][index]);
             meshRenderData.UpdateMaterialBuffer(i);
         }

--- a/src/vulkan/vulkan_types.h
+++ b/src/vulkan/vulkan_types.h
@@ -82,8 +82,8 @@ namespace IC {
         MaterialFlags materialFlags;
 
         bool operator<(const Pipeline &other) const {
-            return pipeline < other.pipeline &&
-                   (materialFlags & MaterialFlags::Transparent) <= (other.materialFlags & MaterialFlags::Transparent);
+            return pipeline < other.pipeline && (materialFlags & MaterialFlags::MaterialFlagsTransparent) <=
+                                                    (other.materialFlags & MaterialFlags::MaterialFlagsTransparent);
         }
     };
 


### PR DESCRIPTION
📝 This is targeting the Window Abstraction branch, not main.

- Sets up a barebones core event system (will be used for app/window/input events).
- Wires up window closing/resizing to leverage these events.
- Refactors `MaterialFlags` enum properties.

Again, this is pretty much just lifted from [Hazel](https://github.dev/TheCherno/Hazel).