### PR TITLE
GameObjects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,8 @@ endif()
 add_library(${PROJECT_NAME}
     src/ic_app.cpp
     src/ic_camera.cpp
+    src/ic_components.cpp
+    src/ic_gameobject.cpp
     src/ic_graphics.cpp
     src/ic_log.cpp
     src/ic_material.cpp

--- a/imgui.ini
+++ b/imgui.ini
@@ -20,10 +20,14 @@ Pos=1216,28
 Size=304,86
 
 [Window][test mesh]
-Pos=60,60
-Size=103,77
+Pos=54,368
+Size=312,169
 
 [Window][directional light]
-Pos=60,60
-Size=430,137
+Pos=54,539
+Size=345,144
+
+[Window][point light]
+Pos=54,686
+Size=312,193
 

--- a/imgui.ini
+++ b/imgui.ini
@@ -5,7 +5,6 @@ Size=400,400
 [Window][Dear ImGui Demo]
 Pos=12,14
 Size=513,439
-Collapsed=1
 
 [Window][Point Light Parameters]
 Pos=1200,694

--- a/imgui.ini
+++ b/imgui.ini
@@ -16,6 +16,14 @@ Pos=1188,565
 Size=378,130
 
 [Window][Render Stats]
-Pos=12,11
+Pos=1216,28
 Size=304,86
+
+[Window][test mesh]
+Pos=60,60
+Size=103,77
+
+[Window][directional light]
+Pos=60,60
+Size=430,137
 

--- a/include/ic_components.h
+++ b/include/ic_components.h
@@ -1,0 +1,121 @@
+#pragma once
+
+#include "ic_graphics.h"
+
+#include <glm/glm.hpp>
+#include <imgui.h>
+
+#include <vector>
+
+namespace IC {
+    class GameObjectComponent {
+    public:
+        GameObjectComponent();
+        ~GameObjectComponent();
+
+        virtual void Gui() = 0;
+
+    protected:
+    };
+
+    class Transform : public GameObjectComponent {
+    public:
+        Transform();
+        ~Transform();
+
+        glm::vec3 Position() { return _position; }
+        glm::vec3 Rotation() { return _rotation; }
+        glm::vec3 Scale() { return _scale; }
+
+        void SetPosition(glm::vec3 position) { _position = position; }
+        void SetRotation(glm::vec3 rotation) { _rotation = rotation; }
+        void SetScale(glm::vec3 scale) { _scale = scale; }
+
+        void Gui() override;
+
+    private:
+        glm::vec3 _position = glm::vec3(0.0f);
+        glm::vec3 _rotation = glm::vec3(0.0f);
+        glm::vec3 _scale = glm::vec3(0.0f);
+    };
+
+    class Mesh : public GameObjectComponent {
+    public:
+        Mesh();
+        ~Mesh();
+
+        MaterialInstance *Material() { return _material.get(); }
+        std::vector<VertexData> &Vertices() { return _vertices; }
+        std::vector<uint32_t> &Indices() { return _indices; }
+        uint32_t VertexCount() { return _vertexCount; }
+        uint32_t IndexCount() { return _indexCount; }
+
+        void SetMaterial(std::shared_ptr<MaterialInstance> &material) { _material = material; }
+
+        void Gui() override;
+
+    private:
+        void LoadMesh();
+
+        std::shared_ptr<MaterialInstance> _material;
+
+        std::vector<VertexData> _vertices;
+        std::vector<uint32_t> _indices;
+        uint32_t _vertexCount;
+        uint32_t _indexCount;
+
+        std::string _filename = "resources/models/cube.obj";
+    };
+
+    class PointLight : public GameObjectComponent {
+    public:
+        PointLight();
+        ~PointLight();
+
+        glm::vec3 Color() { return _color; }
+        glm::vec3 Ambient() { return _ambient; }
+        glm::vec3 Specular() { return _specular; }
+        float Constant() { return _constant; }
+        float Linear() { return _linear; }
+        float Quadratic() { return _quadratic; }
+
+        void SetColor(glm::vec3 color) { _color = color; }
+        void SetAmbient(glm::vec3 ambient) { _ambient = ambient; }
+        void SetSpecular(glm::vec3 specular) { _specular = specular; }
+
+        void Gui() override;
+
+    private:
+        glm::vec3 _color = glm::vec3(1.0f);
+        glm::vec3 _ambient = glm::vec3(0.1f);
+        glm::vec3 _specular = glm::vec3(1.0f);
+
+        float _constant = 1.0f;
+        float _linear = 0.09f;
+        float _quadratic = 0.032f;
+    };
+
+    class DirectionalLight : public GameObjectComponent {
+    public:
+        DirectionalLight();
+        ~DirectionalLight();
+
+        glm::vec3 Direction() { return _direction; }
+        glm::vec3 Color() { return _color; }
+        glm::vec3 Ambient() { return _ambient; }
+        glm::vec3 Specular() { return _specular; }
+
+        void SetDirection(glm::vec3 direction) { _direction = direction; }
+        void SetColor(glm::vec3 color) { _color = color; }
+        void SetAmbient(glm::vec3 ambient) { _ambient = ambient; }
+        void SetSpecular(glm::vec3 specular) { _specular = specular; }
+
+        void Gui() override;
+
+    private:
+        glm::vec3 _direction;
+        glm::vec3 _color = glm::vec3(1.0f);
+        glm::vec3 _ambient = glm::vec3(0.1f);
+        glm::vec3 _specular = glm::vec3(1.0f);
+    };
+} // namespace IC

--- a/include/ic_components.h
+++ b/include/ic_components.h
@@ -44,12 +44,14 @@ namespace IC {
         Mesh();
         ~Mesh();
 
+        bool MeshUpdated() { return _meshUpdatedFlag; }
         MaterialInstance *Material() { return _material.get(); }
         std::vector<VertexData> &Vertices() { return _vertices; }
         std::vector<uint32_t> &Indices() { return _indices; }
         uint32_t VertexCount() { return _vertexCount; }
         uint32_t IndexCount() { return _indexCount; }
 
+        void ClearMeshUpdatedFlag() { _meshUpdatedFlag = false; }
         void SetMaterial(std::shared_ptr<MaterialInstance> &material) { _material = material; }
 
         void Gui() override;
@@ -58,13 +60,14 @@ namespace IC {
         void LoadMesh();
 
         std::shared_ptr<MaterialInstance> _material;
+        std::string _filename = "resources/models/cube.obj";
 
         std::vector<VertexData> _vertices;
         std::vector<uint32_t> _indices;
         uint32_t _vertexCount;
         uint32_t _indexCount;
 
-        std::string _filename = "resources/models/cube.obj";
+        bool _meshUpdatedFlag = false;
     };
 
     class PointLight : public GameObjectComponent {

--- a/include/ic_components.h
+++ b/include/ic_components.h
@@ -8,38 +8,29 @@
 #include <vector>
 
 namespace IC {
-    class GameObjectComponent {
+    class Component {
     public:
-        GameObjectComponent();
-        ~GameObjectComponent();
+        Component();
+        virtual ~Component() = 0;
 
         virtual void Gui() = 0;
 
     protected:
     };
 
-    class Transform : public GameObjectComponent {
+    class Transform : public Component {
     public:
         Transform();
         ~Transform();
 
-        glm::vec3 Position() { return _position; }
-        glm::vec3 Rotation() { return _rotation; }
-        glm::vec3 Scale() { return _scale; }
-
-        void SetPosition(glm::vec3 position) { _position = position; }
-        void SetRotation(glm::vec3 rotation) { _rotation = rotation; }
-        void SetScale(glm::vec3 scale) { _scale = scale; }
+        glm::vec3 position = glm::vec3(0.0f);
+        glm::vec3 rotation = glm::vec3(0.0f);
+        glm::vec3 scale = glm::vec3(0.0f);
 
         void Gui() override;
-
-    private:
-        glm::vec3 _position = glm::vec3(0.0f);
-        glm::vec3 _rotation = glm::vec3(0.0f);
-        glm::vec3 _scale = glm::vec3(0.0f);
     };
 
-    class Mesh : public GameObjectComponent {
+    class Mesh : public Component {
     public:
         Mesh();
         ~Mesh();
@@ -70,55 +61,37 @@ namespace IC {
         bool _meshUpdatedFlag = false;
     };
 
-    class PointLight : public GameObjectComponent {
+    class PointLight : public Component {
     public:
         PointLight();
         ~PointLight();
 
-        glm::vec3 Color() { return _color; }
-        glm::vec3 Ambient() { return _ambient; }
-        glm::vec3 Specular() { return _specular; }
         float Constant() { return _constant; }
         float Linear() { return _linear; }
         float Quadratic() { return _quadratic; }
 
-        void SetColor(glm::vec3 color) { _color = color; }
-        void SetAmbient(glm::vec3 ambient) { _ambient = ambient; }
-        void SetSpecular(glm::vec3 specular) { _specular = specular; }
-
         void Gui() override;
 
-    private:
-        glm::vec3 _color = glm::vec3(1.0f);
-        glm::vec3 _ambient = glm::vec3(0.1f);
-        glm::vec3 _specular = glm::vec3(1.0f);
+        glm::vec3 color = glm::vec3(1.0f);
+        glm::vec3 ambient = glm::vec3(0.1f);
+        glm::vec3 specular = glm::vec3(1.0f);
 
+    private:
         float _constant = 1.0f;
         float _linear = 0.09f;
         float _quadratic = 0.032f;
     };
 
-    class DirectionalLight : public GameObjectComponent {
+    class DirectionalLight : public Component {
     public:
         DirectionalLight();
         ~DirectionalLight();
 
-        glm::vec3 Direction() { return _direction; }
-        glm::vec3 Color() { return _color; }
-        glm::vec3 Ambient() { return _ambient; }
-        glm::vec3 Specular() { return _specular; }
-
-        void SetDirection(glm::vec3 direction) { _direction = direction; }
-        void SetColor(glm::vec3 color) { _color = color; }
-        void SetAmbient(glm::vec3 ambient) { _ambient = ambient; }
-        void SetSpecular(glm::vec3 specular) { _specular = specular; }
+        glm::vec3 direction;
+        glm::vec3 color = glm::vec3(1.0f);
+        glm::vec3 ambient = glm::vec3(0.1f);
+        glm::vec3 specular = glm::vec3(1.0f);
 
         void Gui() override;
-
-    private:
-        glm::vec3 _direction;
-        glm::vec3 _color = glm::vec3(1.0f);
-        glm::vec3 _ambient = glm::vec3(0.1f);
-        glm::vec3 _specular = glm::vec3(1.0f);
     };
 } // namespace IC

--- a/include/ic_components.h
+++ b/include/ic_components.h
@@ -11,7 +11,7 @@ namespace IC {
     class Component {
     public:
         Component();
-        virtual ~Component() = 0;
+        virtual ~Component();
 
         virtual void Gui() = 0;
 

--- a/include/ic_gameobject.h
+++ b/include/ic_gameobject.h
@@ -11,10 +11,10 @@ namespace IC {
         GameObject(std::string name);
         ~GameObject();
 
-        std::vector<std::unique_ptr<GameObjectComponent>> &Components() { return _components; }
-        std::unique_ptr<Transform> &GetTransform() { return _transform; }
+        std::vector<std::shared_ptr<GameObjectComponent>> &Components() { return _components; }
+        std::shared_ptr<Transform> &GetTransform() { return _transform; }
         template <typename T> void AddComponent(const T &component) {
-            _components.push_back(std::make_unique<T>(component));
+            _components.push_back(std::make_shared<T>(component));
         }
         template <typename T> GameObjectComponent *GetComponent() {
             for (auto component : _components) {
@@ -28,7 +28,7 @@ namespace IC {
 
     private:
         std::string _name;
-        std::unique_ptr<Transform> _transform;
-        std::vector<std::unique_ptr<GameObjectComponent>> _components;
+        std::shared_ptr<Transform> _transform;
+        std::vector<std::shared_ptr<GameObjectComponent>> _components;
     };
 } // namespace IC

--- a/include/ic_gameobject.h
+++ b/include/ic_gameobject.h
@@ -3,6 +3,8 @@
 #include "ic_components.h"
 
 #include <memory>
+#include <typeindex>
+#include <typeinfo>
 #include <vector>
 
 namespace IC {
@@ -11,16 +13,20 @@ namespace IC {
         GameObject(std::string name);
         ~GameObject();
 
-        std::vector<std::shared_ptr<GameObjectComponent>> &Components() { return _components; }
         std::shared_ptr<Transform> &GetTransform() { return _transform; }
-        template <typename T> void AddComponent(const T &component) {
-            _components.push_back(std::make_shared<T>(component));
+
+        template <typename T> std::shared_ptr<T> AddComponent() {
+            _componentMap[typeid(T)] = std::make_shared<T>();
+            return static_pointer_cast<T>(_componentMap[typeid(T)]);
         }
-        template <typename T> GameObjectComponent *GetComponent() {
-            for (auto component : _components) {
-                if (typeid(*component) == typeid(T)) {
-                    return component.get();
-                }
+
+        template <typename T> bool HasComponent() { return _componentMap.contains(typeid(T)); }
+
+        template <typename T> std::shared_ptr<T> GetComponent() {
+            if (HasComponent<T>()) {
+                return static_pointer_cast<T>(_componentMap.at(typeid(T)));
+            } else {
+                return nullptr;
             }
         }
 
@@ -29,6 +35,6 @@ namespace IC {
     private:
         std::string _name;
         std::shared_ptr<Transform> _transform;
-        std::vector<std::shared_ptr<GameObjectComponent>> _components;
+        std::map<std::type_index, std::shared_ptr<Component>> _componentMap;
     };
 } // namespace IC

--- a/include/ic_gameobject.h
+++ b/include/ic_gameobject.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "ic_components.h"
+
+#include <memory>
+#include <vector>
+
+namespace IC {
+    class GameObject {
+    public:
+        GameObject(std::string name);
+        ~GameObject();
+
+        std::vector<std::unique_ptr<GameObjectComponent>> &Components() { return _components; }
+        std::unique_ptr<Transform> &GetTransform() { return _transform; }
+        template <typename T> void AddComponent(const T &component) {
+            _components.push_back(std::make_unique<T>(component));
+        }
+        template <typename T> GameObjectComponent *GetComponent() {
+            for (auto component : _components) {
+                if (typeid(*component) == typeid(T)) {
+                    return component.get();
+                }
+            }
+        }
+
+        void Gui();
+
+    private:
+        std::string _name;
+        std::unique_ptr<Transform> _transform;
+        std::vector<std::unique_ptr<GameObjectComponent>> _components;
+    };
+} // namespace IC

--- a/include/ic_gameobject.h
+++ b/include/ic_gameobject.h
@@ -14,13 +14,18 @@ namespace IC {
         ~GameObject();
 
         std::shared_ptr<Transform> &GetTransform() { return _transform; }
+        template <typename T> bool HasComponent() { return _componentMap.contains(typeid(T)); }
 
         template <typename T> std::shared_ptr<T> AddComponent() {
+            // return component if game object already has one attached
+            if (HasComponent<T>()) {
+                return static_pointer_cast<T>(_componentMap.at(typeid(T)));
+            }
+
+            // otherwise create new component of type T
             _componentMap[typeid(T)] = std::make_shared<T>();
             return static_pointer_cast<T>(_componentMap[typeid(T)]);
         }
-
-        template <typename T> bool HasComponent() { return _componentMap.contains(typeid(T)); }
 
         template <typename T> std::shared_ptr<T> GetComponent() {
             if (HasComponent<T>()) {

--- a/include/ic_graphics.h
+++ b/include/ic_graphics.h
@@ -27,64 +27,6 @@ namespace IC {
             return pos == other.pos && normal == other.normal && color == other.color && texCoord == other.texCoord;
         }
     };
-
-    struct Mesh {
-        std::vector<VertexData> vertices;
-        std::vector<uint32_t> indices;
-        uint32_t vertexCount;
-        uint32_t indexCount;
-        glm::vec3 pos;
-        glm::vec3 scale;
-        glm::vec3 rotation;
-
-        void LoadFromFile(std::string fileName);
-    };
-
-    struct Light {};
-
-    // lights
-    struct PointLight : Light {
-        // todo: move mesh and material to gameobject/gameobject components
-        glm::vec3 color;
-        glm::vec3 ambient;
-        glm::vec3 specular;
-
-        // lighting falloff parameters
-        float constant = 1.0f;
-        float linear = 0.09f;
-        float quadratic = 0.032f;
-
-        Mesh previewMesh;
-        MaterialInstance *previewMaterial;
-
-        void ParameterGui() {
-            ImGui::Begin("Point Light Parameters");
-            ImGui::DragFloat3("Light Position", (float *)&previewMesh.pos, 0.01, FLT_MIN, FLT_MAX, "%.3f", 0);
-            ImGui::ColorEdit3("Light Color", (float *)&color);
-            ImGui::ColorEdit3("Ambient", (float *)&ambient);
-            ImGui::ColorEdit3("Specular", (float *)&specular);
-            ImGui::DragFloat("Constant", &constant, 0.01, 0.0, FLT_MAX);
-            ImGui::DragFloat("Linear", &linear, 0.01, 0.0, FLT_MAX);
-            ImGui::DragFloat("Quadratic", &quadratic, 0.01, 0.0, FLT_MAX);
-            ImGui::End();
-        }
-    };
-
-    struct DirectionalLight : Light {
-        glm::vec3 direction;
-        glm::vec3 color;
-        glm::vec3 ambient;
-        glm::vec3 specular;
-
-        void ParameterGui() {
-            ImGui::Begin("Directional Light Parameters");
-            ImGui::DragFloat3("Light Direction", (float *)&direction, 0.01);
-            ImGui::ColorEdit3("Light Color", (float *)&color);
-            ImGui::ColorEdit3("Ambient", (float *)&ambient);
-            ImGui::ColorEdit3("Specular", (float *)&specular);
-            ImGui::End();
-        }
-    };
 } // namespace IC
 
 namespace std {

--- a/src/ic_app.cpp
+++ b/src/ic_app.cpp
@@ -79,27 +79,23 @@ bool App::Run(const Config *c) {
 
     // mesh game object
     auto mesh = std::make_shared<GameObject>("test mesh");
-    Mesh meshComponent{};
-    mesh->GetTransform()->SetScale(glm::vec3(0.5f));
-    meshComponent.SetMaterial(meshMaterialInstance);
-    mesh->AddComponent<Mesh>(meshComponent);
+    auto meshComponent = mesh->AddComponent<Mesh>();
+    meshComponent->SetMaterial(meshMaterialInstance);
+    mesh->GetTransform()->scale = glm::vec3(0.5f);
 
     // test light
     auto pointLight = std::make_shared<GameObject>("point light");
-    Mesh pointLightMesh{};
-    PointLight pointLightComponent{};
-    pointLight->GetTransform()->SetPosition(glm::vec3(1.7f, 1.0f, 1.0f));
-    pointLight->GetTransform()->SetScale(glm::vec3(0.1f));
-    pointLightMesh.SetMaterial(unlitMaterialInstance);
-    pointLight->AddComponent<PointLight>(pointLightComponent);
-    pointLight->AddComponent<Mesh>(pointLightMesh);
+    pointLight->AddComponent<PointLight>();
+    auto pointLightMesh = pointLight->AddComponent<Mesh>();
+    pointLight->GetTransform()->position = glm::vec3(1.7f, 1.0f, 1.0f);
+    pointLight->GetTransform()->scale = glm::vec3(0.1f);
+    pointLightMesh->SetMaterial(unlitMaterialInstance);
 
     // directional light
     auto dirLight = std::make_shared<GameObject>("directional light");
-    DirectionalLight dirLightComponent{};
-    dirLightComponent.SetDirection({0.0f, 0.0f, 1.0f});
-    dirLightComponent.SetAmbient(glm::vec3(0.2f));
-    dirLight->AddComponent<DirectionalLight>(dirLightComponent);
+    auto dirLightComponent = dirLight->AddComponent<DirectionalLight>();
+    dirLightComponent->direction = {0.0f, 0.0f, 1.0f};
+    dirLightComponent->ambient = glm::vec3(0.2f);
 
     appRendererApi->AddGameObject(mesh);
     appRendererApi->AddGameObject(pointLight);

--- a/src/ic_app.cpp
+++ b/src/ic_app.cpp
@@ -105,7 +105,8 @@ bool App::Run(const Config *c) {
     appRendererApi->AddGameObject(pointLight);
     appRendererApi->AddGameObject(dirLight);
     appRendererApi->AddImguiFunction("game object", std::bind(&GameObject::Gui, mesh.get()));
-    appRendererApi->AddImguiFunction("point light", std::bind(&GameObject::Gui, dirLight.get()));
+    appRendererApi->AddImguiFunction("point light", std::bind(&GameObject::Gui, pointLight.get()));
+    appRendererApi->AddImguiFunction("directional light", std::bind(&GameObject::Gui, dirLight.get()));
 
     while (!glfwWindowShouldClose(window)) {
         glfwPollEvents();

--- a/src/ic_components.cpp
+++ b/src/ic_components.cpp
@@ -6,9 +6,9 @@
 #include <tiny_obj_loader.h>
 
 namespace IC {
-    GameObjectComponent::GameObjectComponent() {}
+    Component::Component() {}
 
-    GameObjectComponent::~GameObjectComponent() {}
+    Component::~Component() {}
 
     Transform::Transform() {}
 
@@ -16,9 +16,9 @@ namespace IC {
 
     void Transform::Gui() {
         ImGui::SeparatorText("TRANSFORM");
-        ImGui::DragFloat3("Position", (float *)&_position, 0.01);
-        ImGui::DragFloat3("Rotation", (float *)&_rotation);
-        ImGui::DragFloat3("Scale", (float *)&_scale);
+        ImGui::DragFloat3("Position", (float *)&position, 0.01);
+        ImGui::DragFloat3("Rotation", (float *)&rotation);
+        ImGui::DragFloat3("Scale", (float *)&scale);
     }
 
     Mesh::Mesh() {
@@ -86,9 +86,9 @@ namespace IC {
 
     void PointLight::Gui() {
         ImGui::SeparatorText("POINT LIGHT");
-        ImGui::ColorEdit3("Light Color", (float *)&_color);
-        ImGui::ColorEdit3("Ambient", (float *)&_ambient);
-        ImGui::ColorEdit3("Specular", (float *)&_specular);
+        ImGui::ColorEdit3("Light Color", (float *)&color);
+        ImGui::ColorEdit3("Ambient", (float *)&ambient);
+        ImGui::ColorEdit3("Specular", (float *)&specular);
     }
 
     DirectionalLight::DirectionalLight() {}
@@ -97,9 +97,9 @@ namespace IC {
 
     void DirectionalLight::Gui() {
         ImGui::SeparatorText("DIRECTIONAL LIGHT");
-        ImGui::DragFloat3("Light Direction", (float *)&_direction, 0.01);
-        ImGui::ColorEdit3("Light Color", (float *)&_color);
-        ImGui::ColorEdit3("Ambient", (float *)&_ambient);
-        ImGui::ColorEdit3("Specular", (float *)&_specular);
+        ImGui::DragFloat3("Light Direction", (float *)&direction, 0.01);
+        ImGui::ColorEdit3("Light Color", (float *)&color);
+        ImGui::ColorEdit3("Ambient", (float *)&ambient);
+        ImGui::ColorEdit3("Specular", (float *)&specular);
     }
 } // namespace IC

--- a/src/ic_components.cpp
+++ b/src/ic_components.cpp
@@ -1,0 +1,97 @@
+#include <ic_components.h>
+
+#include "ic_log.h"
+
+#include <imgui_stdlib.h>
+#include <tiny_obj_loader.h>
+
+namespace IC {
+    GameObjectComponent::GameObjectComponent() {}
+
+    GameObjectComponent::~GameObjectComponent() {}
+
+    Transform::Transform() {}
+
+    Transform::~Transform() {}
+
+    void Transform::Gui() {
+        ImGui::DragFloat3("Position", (float *)&_position, 0.01);
+        ImGui::DragFloat3("Rotation", (float *)&_rotation);
+        ImGui::DragFloat3("Scale", (float *)&_scale);
+        ImGui::End();
+    }
+
+    Mesh::Mesh() {
+        LoadMesh();
+    }
+
+    Mesh::~Mesh() {}
+
+    void Mesh::LoadMesh() {
+        tinyobj::attrib_t attrib;
+        std::vector<tinyobj::shape_t> shapes;
+        std::vector<tinyobj::material_t> materials;
+        std::string warn, err;
+
+        if (!tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err, _filename.c_str())) {
+            IC_CORE_ERROR("Failed to load {0}.", _filename);
+        }
+
+        std::unordered_map<VertexData, uint32_t> uniqueVertices{};
+
+        for (const auto &shape : shapes) {
+            for (const auto &index : shape.mesh.indices) {
+                VertexData vertex{};
+
+                vertex.pos = {attrib.vertices[3 * index.vertex_index + 0], attrib.vertices[3 * index.vertex_index + 1],
+                              attrib.vertices[3 * index.vertex_index + 2]};
+
+                vertex.normal = {attrib.normals[3 * index.normal_index + 0], attrib.normals[3 * index.normal_index + 1],
+                                 attrib.normals[3 * index.normal_index + 2]};
+
+                vertex.texCoord = {attrib.texcoords[2 * index.texcoord_index + 0],
+                                   1.0f - attrib.texcoords[2 * index.texcoord_index + 1]};
+
+                vertex.color = {1.0f, 1.0f, 1.0f};
+
+                if (uniqueVertices.count(vertex) == 0) {
+                    uniqueVertices[vertex] = static_cast<uint32_t>(_vertices.size());
+                    _vertices.push_back(vertex);
+                }
+
+                _indices.push_back(uniqueVertices[vertex]);
+            }
+        }
+
+        _vertexCount = static_cast<uint32_t>(_vertices.size());
+        _indexCount = static_cast<uint32_t>(_indices.size());
+    }
+
+    void Mesh::Gui() {
+        ImGui::InputText("File Name", &_filename);
+        if (ImGui::Button("Load Mesh")) {
+            LoadMesh();
+        }
+    }
+
+    PointLight::PointLight() {}
+
+    PointLight::~PointLight() {}
+
+    void PointLight::Gui() {
+        ImGui::ColorEdit3("Light Color", (float *)&_color);
+        ImGui::ColorEdit3("Ambient", (float *)&_ambient);
+        ImGui::ColorEdit3("Specular", (float *)&_specular);
+    }
+
+    DirectionalLight::DirectionalLight() {}
+
+    DirectionalLight::~DirectionalLight() {}
+
+    void DirectionalLight::Gui() {
+        ImGui::DragFloat3("Light Direction", (float *)&_direction, 0.01);
+        ImGui::ColorEdit3("Light Color", (float *)&_color);
+        ImGui::ColorEdit3("Ambient", (float *)&_ambient);
+        ImGui::ColorEdit3("Specular", (float *)&_specular);
+    }
+} // namespace IC

--- a/src/ic_components.cpp
+++ b/src/ic_components.cpp
@@ -28,6 +28,9 @@ namespace IC {
     Mesh::~Mesh() {}
 
     void Mesh::LoadMesh() {
+        _vertices.clear();
+        _indices.clear();
+
         tinyobj::attrib_t attrib;
         std::vector<tinyobj::shape_t> shapes;
         std::vector<tinyobj::material_t> materials;
@@ -65,6 +68,8 @@ namespace IC {
 
         _vertexCount = static_cast<uint32_t>(_vertices.size());
         _indexCount = static_cast<uint32_t>(_indices.size());
+
+        _meshUpdatedFlag = true;
     }
 
     void Mesh::Gui() {

--- a/src/ic_components.cpp
+++ b/src/ic_components.cpp
@@ -15,10 +15,10 @@ namespace IC {
     Transform::~Transform() {}
 
     void Transform::Gui() {
+        ImGui::SeparatorText("TRANSFORM");
         ImGui::DragFloat3("Position", (float *)&_position, 0.01);
         ImGui::DragFloat3("Rotation", (float *)&_rotation);
         ImGui::DragFloat3("Scale", (float *)&_scale);
-        ImGui::End();
     }
 
     Mesh::Mesh() {
@@ -73,6 +73,7 @@ namespace IC {
     }
 
     void Mesh::Gui() {
+        ImGui::SeparatorText("MESH");
         ImGui::InputText("File Name", &_filename);
         if (ImGui::Button("Load Mesh")) {
             LoadMesh();
@@ -84,6 +85,7 @@ namespace IC {
     PointLight::~PointLight() {}
 
     void PointLight::Gui() {
+        ImGui::SeparatorText("POINT LIGHT");
         ImGui::ColorEdit3("Light Color", (float *)&_color);
         ImGui::ColorEdit3("Ambient", (float *)&_ambient);
         ImGui::ColorEdit3("Specular", (float *)&_specular);
@@ -94,6 +96,7 @@ namespace IC {
     DirectionalLight::~DirectionalLight() {}
 
     void DirectionalLight::Gui() {
+        ImGui::SeparatorText("DIRECTIONAL LIGHT");
         ImGui::DragFloat3("Light Direction", (float *)&_direction, 0.01);
         ImGui::ColorEdit3("Light Color", (float *)&_color);
         ImGui::ColorEdit3("Ambient", (float *)&_ambient);

--- a/src/ic_gameobject.cpp
+++ b/src/ic_gameobject.cpp
@@ -2,7 +2,7 @@
 
 namespace IC {
     GameObject::GameObject(std::string name) : _name{name} {
-        _transform = std::make_unique<Transform>();
+        _transform = std::make_shared<Transform>();
     }
     GameObject::~GameObject() {}
 

--- a/src/ic_gameobject.cpp
+++ b/src/ic_gameobject.cpp
@@ -1,0 +1,17 @@
+#include <ic_gameobject.h>
+
+namespace IC {
+    GameObject::GameObject(std::string name) : _name{name} {
+        _transform = std::make_unique<Transform>();
+    }
+    GameObject::~GameObject() {}
+
+    void GameObject::Gui() {
+        ImGui::Begin(_name.c_str());
+        for (auto &component : _components) {
+            component->Gui();
+        }
+        ImGui::End();
+    }
+
+} // namespace IC

--- a/src/ic_gameobject.cpp
+++ b/src/ic_gameobject.cpp
@@ -9,7 +9,7 @@ namespace IC {
     void GameObject::Gui() {
         ImGui::Begin(_name.c_str());
         _transform->Gui();
-        for (auto &component : _components) {
+        for (auto &[key, component] : _componentMap) {
             component->Gui();
         }
         ImGui::End();

--- a/src/ic_gameobject.cpp
+++ b/src/ic_gameobject.cpp
@@ -8,6 +8,7 @@ namespace IC {
 
     void GameObject::Gui() {
         ImGui::Begin(_name.c_str());
+        _transform->Gui();
         for (auto &component : _components) {
             component->Gui();
         }

--- a/src/ic_graphics.cpp
+++ b/src/ic_graphics.cpp
@@ -4,47 +4,4 @@
 
 #include <tiny_obj_loader.h>
 
-namespace IC {
-    void Mesh::LoadFromFile(std::string fileName) {
-
-        tinyobj::attrib_t attrib;
-        std::vector<tinyobj::shape_t> shapes;
-        std::vector<tinyobj::material_t> materials;
-        std::string warn, err;
-
-        if (!tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err, fileName.c_str())) {
-            IC_CORE_ERROR("Failed to load {0}.", fileName);
-            throw std::runtime_error(warn + err);
-        }
-
-        std::unordered_map<VertexData, uint32_t> uniqueVertices{};
-
-        for (const auto &shape : shapes) {
-            for (const auto &index : shape.mesh.indices) {
-                VertexData vertex{};
-
-                vertex.pos = {attrib.vertices[3 * index.vertex_index + 0], attrib.vertices[3 * index.vertex_index + 1],
-                              attrib.vertices[3 * index.vertex_index + 2]};
-
-                vertex.normal = {attrib.normals[3 * index.normal_index + 0], attrib.normals[3 * index.normal_index + 1],
-                                 attrib.normals[3 * index.normal_index + 2]};
-
-                vertex.texCoord = {attrib.texcoords[2 * index.texcoord_index + 0],
-                                   1.0f - attrib.texcoords[2 * index.texcoord_index + 1]};
-
-                vertex.color = {1.0f, 1.0f, 1.0f};
-
-                if (uniqueVertices.count(vertex) == 0) {
-                    uniqueVertices[vertex] = static_cast<uint32_t>(vertices.size());
-                    vertices.push_back(vertex);
-                }
-
-                indices.push_back(uniqueVertices[vertex]);
-            }
-        }
-
-        vertexCount = static_cast<uint32_t>(vertices.size());
-        indexCount = static_cast<uint32_t>(indices.size());
-        assert(vertexCount >= 3 && "Vertex count must be at least 3");
-    }
-} // namespace IC
+namespace IC {} // namespace IC

--- a/src/ic_renderer.h
+++ b/src/ic_renderer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ic_gameobject.h>
 #include <ic_graphics.h>
 
 #include <GLFW/glfw3.h>
@@ -33,9 +34,7 @@ namespace IC {
 
         static Renderer *MakeRenderer(const RendererConfig &rendererConfig);
 
-        virtual void AddMesh(Mesh &meshData, MaterialInstance *materialData) = 0;
-        virtual void AddLight(std::shared_ptr<PointLight> light) = 0;
-        virtual void AddDirectionalLight(std::shared_ptr<DirectionalLight> light) = 0;
+        virtual void AddGameObject(std::shared_ptr<GameObject> object) = 0;
         virtual void DrawFrame() = 0;
 
         void AddImguiFunction(std::string windowName, std::function<void()> function);

--- a/src/vulkan/vulkan_allocator.cpp
+++ b/src/vulkan/vulkan_allocator.cpp
@@ -61,6 +61,7 @@ namespace IC {
         vmaDestroyBuffer(_allocator, buffer.buffer, buffer.allocation);
 
         buffer.buffer = nullptr;
+        buffer.allocation = nullptr;
     }
 
     void VulkanAllocator::DestroyImage(AllocatedImage &image) {

--- a/src/vulkan/vulkan_initializers.cpp
+++ b/src/vulkan/vulkan_initializers.cpp
@@ -189,31 +189,30 @@ namespace IC {
 
     SceneLightDescriptors CreateSceneLightDescriptors(SceneLightData &lightData, glm::mat4 viewMat) {
         SceneLightDescriptors descriptors;
-        glm::vec3 directionalViewSpaceDirection = viewMat * glm::vec4(lightData.directionalLight->Direction(), 0.0f);
+        glm::vec3 directionalViewSpaceDirection = viewMat * glm::vec4(lightData.directionalLight->direction, 0.0f);
 
         DirectionalLightDescriptors directionalDescriptors{};
         directionalDescriptors.dir = directionalViewSpaceDirection;
-        directionalDescriptors.diff = lightData.directionalLight->Color();
-        directionalDescriptors.amb = lightData.directionalLight->Ambient();
-        directionalDescriptors.spec = lightData.directionalLight->Specular();
+        directionalDescriptors.diff = lightData.directionalLight->color;
+        directionalDescriptors.amb = lightData.directionalLight->ambient;
+        directionalDescriptors.spec = lightData.directionalLight->specular;
         descriptors.directionalLight = directionalDescriptors;
 
         for (int i = 0; i < lightData.pointLights.size() && i < MAX_POINT_LIGHTS; i++) {
-            glm::vec3 lightViewSpacePos = viewMat * glm::vec4(lightData.pointLights[i].transform->Position(), 1.0f);
+            glm::vec3 lightViewSpacePos = viewMat * glm::vec4(lightData.pointLights[i].transform->position, 1.0f);
 
             PointLightDescriptors pointLightDescriptors{};
             pointLightDescriptors.pos = lightViewSpacePos;
-            pointLightDescriptors.amb = lightData.pointLights[i].light->Ambient();
-            pointLightDescriptors.diff = lightData.pointLights[i].light->Color();
-            pointLightDescriptors.spec = lightData.pointLights[i].light->Specular();
+            pointLightDescriptors.amb = lightData.pointLights[i].light->ambient;
+            pointLightDescriptors.diff = lightData.pointLights[i].light->color;
+            pointLightDescriptors.spec = lightData.pointLights[i].light->specular;
             pointLightDescriptors.cons = lightData.pointLights[i].light->Constant();
             pointLightDescriptors.lin = lightData.pointLights[i].light->Linear();
             pointLightDescriptors.quad = lightData.pointLights[i].light->Quadratic();
 
             descriptors.pointLights[i] = pointLightDescriptors;
         }
-        descriptors.numPointLights =
-            lightData.pointLights.size() > MAX_POINT_LIGHTS ? MAX_POINT_LIGHTS : lightData.pointLights.size();
+        descriptors.numPointLights = std::min(static_cast<int>(lightData.pointLights.size()), MAX_POINT_LIGHTS);
         return descriptors;
     }
 

--- a/src/vulkan/vulkan_initializers.cpp
+++ b/src/vulkan/vulkan_initializers.cpp
@@ -188,38 +188,36 @@ namespace IC {
         }
     }
 
-    SceneLightDescriptors CreateSceneLightDescriptors(std::shared_ptr<DirectionalLight> &directionalLight,
-                                                      std::vector<std::shared_ptr<PointLight>> &pointLights,
+    DirectionalLightDescriptors CreateDirectionalLightDescriptors(DirectionalLight *directionalLight,
+                                                                  glm::mat4 viewMat) {
+        glm::vec3 directionalViewSpaceDirection = viewMat * glm::vec4(directionalLight->Direction(), 0.0f);
+
+        DirectionalLightDescriptors descriptors{};
+        descriptors.dir = directionalViewSpaceDirection;
+        descriptors.diff = directionalLight->Color();
+        descriptors.amb = directionalLight->Ambient();
+        descriptors.spec = directionalLight->Specular();
+
+        return descriptors;
+    }
+
+    PointLightDescriptors CreatePointLightDescriptors(PointLight *pointLight, glm::vec3 lightPosition,
                                                       glm::mat4 viewMat) {
-        SceneLightDescriptors descriptors;
-        glm::vec3 directionalViewSpaceDirection = viewMat * glm::vec4(directionalLight->direction, 0.0f);
+        glm::vec3 lightViewSpacePos = viewMat * glm::vec4(lightPosition, 1.0f);
 
-        DirectionalLightDescriptors directionalDescriptors{};
-        directionalDescriptors.dir = directionalViewSpaceDirection;
-        directionalDescriptors.diff = directionalLight->color;
-        directionalDescriptors.amb = directionalLight->ambient;
-        directionalDescriptors.spec = directionalLight->specular;
-        descriptors.directionalLight = directionalDescriptors;
-        for (int i = 0; i < pointLights.size() && i < MAX_POINT_LIGHTS; i++) {
-            glm::vec3 lightViewSpacePos = viewMat * glm::vec4(pointLights[i]->previewMesh.pos, 1.0f);
+        PointLightDescriptors descriptors{};
+        descriptors.pos = lightViewSpacePos;
+        descriptors.diff = pointLight->Color();
+        descriptors.amb = pointLight->Ambient();
+        descriptors.spec = pointLight->Specular();
+        descriptors.cons = pointLight->Constant();
+        descriptors.lin = pointLight->Linear();
+        descriptors.quad = pointLight->Quadratic();
 
-            PointLightDescriptors pointLightDescriptors{};
-            pointLightDescriptors.pos = lightViewSpacePos;
-            pointLightDescriptors.amb = pointLights[i]->ambient;
-            pointLightDescriptors.diff = pointLights[i]->color;
-            pointLightDescriptors.spec = pointLights[i]->specular;
-            pointLightDescriptors.cons = pointLights[i]->constant;
-            pointLightDescriptors.lin = pointLights[i]->linear;
-            pointLightDescriptors.quad = pointLights[i]->quadratic;
-
-            descriptors.pointLights[i] = pointLightDescriptors;
-        }
-        descriptors.numPointLights = pointLights.size() > MAX_POINT_LIGHTS ? MAX_POINT_LIGHTS : pointLights.size();
         return descriptors;
     }
 
     // images
-
     void CreateImageSampler(VkDevice device, float maxAnisotropy, VkSampler &textureSampler) {
         VkSamplerCreateInfo samplerInfo{};
         samplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;

--- a/src/vulkan/vulkan_initializers.h
+++ b/src/vulkan/vulkan_initializers.h
@@ -39,15 +39,12 @@ namespace IC {
     // descriptors
     void WritePerObjectDescriptors(VulkanAllocator &allocator, SwapChain &swapChain, DescriptorWriter &writer,
                                    MeshRenderData &renderData);
-    void WriteLightDescriptors(VulkanAllocator &allocator, size_t maxFrames, SceneLightDescriptors &lightData,
-                               DescriptorWriter &writer, std::vector<AllocatedBuffer> &lightBuffers);
+    void WriteLightDescriptors(VulkanAllocator &allocator, size_t maxFrames, DescriptorWriter &writer,
+                               std::vector<AllocatedBuffer> &lightBuffers);
     void WriteMaterialDescriptors(VulkanAllocator &allocator, size_t maxFrames, DescriptorWriter &writer,
                                   MaterialInstance &material, VulkanTextureManager &textureManager,
                                   std::vector<AllocatedBuffer> &materialBuffers);
-    DirectionalLightDescriptors CreateDirectionalLightDescriptors(DirectionalLight *directionalLight,
-                                                                  glm::mat4 viewMat);
-    PointLightDescriptors CreatePointLightDescriptors(PointLight *pointLight, glm::vec3 lightPosition,
-                                                      glm::mat4 viewMat);
+    SceneLightDescriptors CreateSceneLightDescriptors(SceneLightData &lightData, glm::mat4 viewMat);
 
     // images
     void CreateImageSampler(VkDevice device, float maxAnisotropy, VkSampler &textureSampler);

--- a/src/vulkan/vulkan_initializers.h
+++ b/src/vulkan/vulkan_initializers.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <ic_gameobject.h>
+
 #include "descriptors.h"
 #include "swap_chain.h"
 #include "vulkan_device.h"
@@ -42,8 +44,9 @@ namespace IC {
     void WriteMaterialDescriptors(VulkanAllocator &allocator, size_t maxFrames, DescriptorWriter &writer,
                                   MaterialInstance &material, VulkanTextureManager &textureManager,
                                   std::vector<AllocatedBuffer> &materialBuffers);
-    SceneLightDescriptors CreateSceneLightDescriptors(std::shared_ptr<DirectionalLight> &directionalLight,
-                                                      std::vector<std::shared_ptr<PointLight>> &pointLights,
+    DirectionalLightDescriptors CreateDirectionalLightDescriptors(DirectionalLight *directionalLight,
+                                                                  glm::mat4 viewMat);
+    PointLightDescriptors CreatePointLightDescriptors(PointLight *pointLight, glm::vec3 lightPosition,
                                                       glm::mat4 viewMat);
 
     // images

--- a/src/vulkan/vulkan_renderer.cpp
+++ b/src/vulkan/vulkan_renderer.cpp
@@ -188,10 +188,10 @@ namespace IC {
             vkCmdBindPipeline(_cBuffers[imageIndex], VK_PIPELINE_BIND_POINT_GRAPHICS, data.renderPipeline->pipeline);
 
             TransformationPushConstants pushConstants{};
-            pushConstants.model = glm::translate(glm::mat4(1.0f), data.transform.Position()) *
+            pushConstants.model = glm::translate(glm::mat4(1.0f), data.transform.position) *
                                   glm::rotate(glm::mat4(1.0f), glm::radians(-90.0f), {1.0f, 0.0f, 0.0f}) *
                                   glm::rotate(glm::mat4(1.0f), rotation, {0.0f, 1.0f, 0.0f}) *
-                                  glm::scale(glm::mat4(1.0f), data.transform.Scale());
+                                  glm::scale(glm::mat4(1.0f), data.transform.scale);
             pushConstants.view = glm::lookAt(glm::vec3(2.0f, 2.0f, 2.0f), glm::vec3(0.0f), glm::vec3(0.0f, 0.0f, 1.0f));
 
             vkCmdPushConstants(_cBuffers[imageIndex], data.renderPipeline->layout,
@@ -334,16 +334,16 @@ namespace IC {
     }
 
     void VulkanRenderer::AddGameObject(std::shared_ptr<GameObject> object) {
-        for (auto &component : object->Components()) {
-            if (typeid(*component) == typeid(Mesh)) {
-                AddMesh(*static_cast<Mesh *>(component.get()), *object->GetTransform());
-            } else if (typeid(*component) == typeid(PointLight)) {
-                std::shared_ptr<PointLight> light = std::dynamic_pointer_cast<PointLight>(component);
-                AddPointLight(light, object->GetTransform());
-            } else if (typeid(*component) == typeid(DirectionalLight)) {
-                std::shared_ptr<DirectionalLight> light = std::dynamic_pointer_cast<DirectionalLight>(component);
-                AddDirectionalLight(light);
-            }
+        if (object->HasComponent<Mesh>()) {
+            AddMesh(*object->GetComponent<Mesh>(), *object->GetTransform());
+        }
+        if (object->HasComponent<PointLight>()) {
+            auto light = object->GetComponent<PointLight>();
+            AddPointLight(light, object->GetTransform());
+        }
+        if (object->HasComponent<DirectionalLight>()) {
+            auto light = object->GetComponent<DirectionalLight>();
+            AddDirectionalLight(light);
         }
     }
 

--- a/src/vulkan/vulkan_renderer.h
+++ b/src/vulkan/vulkan_renderer.h
@@ -15,9 +15,7 @@ namespace IC {
         VulkanRenderer(const RendererConfig &config);
         virtual ~VulkanRenderer();
 
-        void AddMesh(Mesh &meshData, MaterialInstance *materialData) override;
-        void AddLight(std::shared_ptr<PointLight> light) override;
-        void AddDirectionalLight(std::shared_ptr<DirectionalLight> light) override;
+        void AddGameObject(std::shared_ptr<GameObject> object) override;
         void DrawFrame() override;
         static void FramebufferResizeCallback(GLFWwindow *window, int width, int height);
 
@@ -27,6 +25,11 @@ namespace IC {
         void InitDescriptorAllocators();
         void RecreateSwapChain();
         void RenderImGui(VkCommandBuffer cBuffer, VkImageView targetImageView);
+
+        // GameObject helpers
+        void AddDirectionalLight(DirectionalLight *light);
+        void AddPointLight(PointLight *light, glm::vec3 position);
+        void AddMesh(Mesh &mesh, Transform &transform);
 
         // function pointers (for mac)
         PFN_vkCmdBeginRenderingKHR VulkanBeginRendering{};
@@ -42,9 +45,9 @@ namespace IC {
         DescriptorAllocator _imGuiDescriptorAllocator{};
 
         // rendering data (mesh, lights)
+        SceneLightDescriptors _lightData{};
         std::vector<MeshRenderData> _renderData{};
-        std::vector<std::shared_ptr<PointLight>> _pointLights;
-        std::shared_ptr<DirectionalLight> _directionalLight;
+        std::vector<std::shared_ptr<GameObject>> _gameObjects;
 
         // command buffers
         std::vector<VkCommandBuffer> _cBuffers{};

--- a/src/vulkan/vulkan_renderer.h
+++ b/src/vulkan/vulkan_renderer.h
@@ -27,8 +27,8 @@ namespace IC {
         void RenderImGui(VkCommandBuffer cBuffer, VkImageView targetImageView);
 
         // GameObject helpers
-        void AddDirectionalLight(DirectionalLight *light);
-        void AddPointLight(PointLight *light, glm::vec3 position);
+        void AddDirectionalLight(std::shared_ptr<DirectionalLight> &light);
+        void AddPointLight(std::shared_ptr<PointLight> &light, std::shared_ptr<Transform> &transform);
         void AddMesh(Mesh &mesh, Transform &transform);
 
         // function pointers (for mac)
@@ -45,9 +45,11 @@ namespace IC {
         DescriptorAllocator _imGuiDescriptorAllocator{};
 
         // rendering data (mesh, lights)
-        SceneLightDescriptors _lightData{};
+        SceneLightData _lightData{};
         std::vector<MeshRenderData> _renderData{};
         std::vector<std::shared_ptr<GameObject>> _gameObjects;
+        DirectionalLight _directionalLight;
+        std::vector<std::shared_ptr<PointLight>> _pointLights;
 
         // command buffers
         std::vector<VkCommandBuffer> _cBuffers{};

--- a/src/vulkan/vulkan_types.h
+++ b/src/vulkan/vulkan_types.h
@@ -52,6 +52,16 @@ namespace IC {
         glm::mat4 view;
     };
 
+    struct PointLightData {
+        std::shared_ptr<PointLight> light;
+        std::shared_ptr<Transform> transform;
+    };
+
+    struct SceneLightData {
+        std::shared_ptr<DirectionalLight> directionalLight;
+        std::vector<PointLightData> pointLights;
+    };
+
     struct DirectionalLightDescriptors {
         alignas(16) glm::vec3 dir;
         alignas(16) glm::vec3 amb;

--- a/src/vulkan/vulkan_types.h
+++ b/src/vulkan/vulkan_types.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ic_gameobject.h>
 #include <ic_graphics.h>
 #include <ic_log.h>
 
@@ -89,7 +90,7 @@ namespace IC {
 
     struct MeshRenderData {
         Mesh &meshData;
-        MaterialInstance &materialData;
+        Transform &transform;
         std::shared_ptr<Pipeline> renderPipeline;
         std::vector<std::vector<VkDescriptorSet>> descriptorSets;
         AllocatedBuffer vertexBuffer;
@@ -108,7 +109,7 @@ namespace IC {
                                     nullptr);
         }
 
-        void Draw(VkCommandBuffer cBuffer) { vkCmdDrawIndexed(cBuffer, meshData.indexCount, 1, 0, 0, 0); }
+        void Draw(VkCommandBuffer cBuffer) { vkCmdDrawIndexed(cBuffer, meshData.IndexCount(), 1, 0, 0, 0); }
 
         void UpdateMvpBuffer(CameraDescriptors uniformBuffer, uint32_t currentImage) {
             memcpy(mvpBuffers[currentImage].allocInfo.pMappedData, &uniformBuffer, sizeof(uniformBuffer));
@@ -116,7 +117,7 @@ namespace IC {
 
         void UpdateMaterialBuffer(uint32_t currentImage) {
             VkDeviceSize offset = 0;
-            for (auto &[index, binding] : materialData.BindingValues()) {
+            for (auto &[index, binding] : meshData.Material()->BindingValues()) {
                 if (binding.binding->bindingType == BindingType::Uniform) {
                     memcpy(static_cast<char *>(materialBuffers[currentImage].allocInfo.pMappedData) + offset,
                            binding.value, binding.size);


### PR DESCRIPTION
Foundation for GameObjects and GameObject components

Adds the following components that can be attached to a game object
- Transform (position, rotation, scale) (GameObjects always have a transform attached)
- Mesh
- Point Light
- Directional Light

GameObjects are passed to the renderer and VulkanRenderer handles them differently based on which components are attached. This design probably needs to change soon, but it works for now. 

GameObjects can also generate a GUI, although I'd like to move this to the Editor application when we can. 

closes #14 and closes #15 