### PR TITLE
🧅 Layers + ⌨️ Keyboard Input

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ add_library(${PROJECT_NAME}
     src/ic_app.cpp
     src/ic_camera.cpp
     src/ic_graphics.cpp
+    src/ic_layer.cpp
     src/ic_log.cpp
     src/ic_material.cpp
     src/ic_renderer.cpp

--- a/editor/main.cpp
+++ b/editor/main.cpp
@@ -1,8 +1,28 @@
 #include <ic.h>
 
+class DummyLayer : public IC::Layer {
+public:
+    DummyLayer() : IC::Layer("Dummy") {}
+
+    void OnAttach() { IC_APP_INFO("Dummy Layer attached"); }
+
+    void OnDetach() { IC_APP_INFO("Dummy Layer detached"); }
+
+    void OnEvent(IC::Event &e) {
+        IC::EventDispatcher dispatcher(e);
+        dispatcher.Dispatch<IC::KeyPressedEvent>([this](IC::KeyPressedEvent &e) { return OnKeyPressed(e); });
+    }
+
+    bool OnKeyPressed(IC::KeyPressedEvent &e) {
+        IC_APP_INFO("Keycode {0} was pressed!", (int)e.GetKeyCode());
+
+        return false;
+    }
+};
+
 class Editor : public IC::App {
 public:
-    Editor(const IC::Config &config) : IC::App(config) {}
+    Editor(const IC::Config &config) : IC::App(config) { PushLayer(new DummyLayer()); }
     ~Editor() {}
 };
 

--- a/include/events/ic_event.h
+++ b/include/events/ic_event.h
@@ -11,11 +11,16 @@ namespace IC {
         // Window events.
         WindowClose,
         WindowResize,
+        // Keyboard events.
+        KeyPressed,
+        KeyReleased
     };
 
     enum EventCategory {
         EventCategoryNone = 0,
         EventCategoryApp = 1 << 0,
+        EventCategoryInput = 1 << 1,
+        EventCategoryKeyboard = 1 << 2
     };
 
 #define EVENT_CLASS_TYPE(type)                                                                                         \

--- a/include/events/ic_key_event.h
+++ b/include/events/ic_key_event.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <ic_keycodes.h>
+
+#include "ic_event.h"
+
+namespace IC {
+    class KeyEvent : public Event {
+    public:
+        KeyCode GetKeyCode() const { return _keyCode; }
+
+        EVENT_CLASS_CATEGORY(EventCategoryKeyboard | EventCategoryInput)
+    protected:
+        KeyEvent(const KeyCode keycode) : _keyCode(keycode) {}
+
+        KeyCode _keyCode;
+    };
+
+    class KeyPressedEvent : public KeyEvent {
+    public:
+        KeyPressedEvent(const KeyCode keycode, bool isRepeat = false) : KeyEvent(keycode), _isRepeat(isRepeat) {}
+
+        bool IsRepeat() const { return _isRepeat; }
+
+        EVENT_CLASS_TYPE(KeyPressed)
+    private:
+        bool _isRepeat;
+    };
+
+    class KeyReleasedEvent : public KeyEvent {
+    public:
+        KeyReleasedEvent(const KeyCode keycode) : KeyEvent(keycode) {}
+
+        EVENT_CLASS_TYPE(KeyReleased)
+    };
+} // namespace IC

--- a/include/ic.h
+++ b/include/ic.h
@@ -1,7 +1,11 @@
 #pragma once
+#include "events/ic_app_event.h"
+#include "events/ic_event.h"
+#include "events/ic_key_event.h"
 #include "ic_app.h"
 #include "ic_camera.h"
 #include "ic_graphics.h"
+#include "ic_keycodes.h"
 #include "ic_layer.h"
 #include "ic_log.h"
 #include "ic_window.h"

--- a/include/ic.h
+++ b/include/ic.h
@@ -2,6 +2,7 @@
 #include "ic_app.h"
 #include "ic_camera.h"
 #include "ic_graphics.h"
+#include "ic_layer.h"
 #include "ic_log.h"
 #include "ic_window.h"
 

--- a/include/ic_app.h
+++ b/include/ic_app.h
@@ -2,6 +2,7 @@
 
 #include "events/ic_app_event.h"
 #include "events/ic_event.h"
+#include "ic_layer.h"
 #include "ic_window.h"
 
 #include <string>
@@ -18,11 +19,15 @@ namespace IC {
 
         void OnEvent(Event &e);
 
+        void PushLayer(Layer *layer);
+        void PushOverlay(Layer *layer);
+
         void Run();
 
     private:
         std::unique_ptr<Window> _window;
         bool _isRunning = true;
+        LayerStack _layerStack;
 
         bool OnWindowClose(WindowCloseEvent &e);
         bool OnWindowResize(WindowResizeEvent &e);

--- a/include/ic_app.h
+++ b/include/ic_app.h
@@ -2,6 +2,7 @@
 
 #include "events/ic_app_event.h"
 #include "events/ic_event.h"
+#include "events/ic_key_event.h"
 #include "ic_layer.h"
 #include "ic_window.h"
 
@@ -29,6 +30,7 @@ namespace IC {
         bool _isRunning = true;
         LayerStack _layerStack;
 
+        bool OnKeyPressed(KeyPressedEvent &e);
         bool OnWindowClose(WindowCloseEvent &e);
         bool OnWindowResize(WindowResizeEvent &e);
     };

--- a/include/ic_keycodes.h
+++ b/include/ic_keycodes.h
@@ -1,0 +1,140 @@
+#pragma once
+
+#include <cstdint>
+#include <ostream>
+
+namespace IC {
+    typedef enum class KeyCode : uint16_t {
+        // From glfw3.h
+        Space = 32,
+        Apostrophe = 39, /* ' */
+        Comma = 44,      /* , */
+        Minus = 45,      /* - */
+        Period = 46,     /* . */
+        Slash = 47,      /* / */
+
+        D0 = 48, /* 0 */
+        D1 = 49, /* 1 */
+        D2 = 50, /* 2 */
+        D3 = 51, /* 3 */
+        D4 = 52, /* 4 */
+        D5 = 53, /* 5 */
+        D6 = 54, /* 6 */
+        D7 = 55, /* 7 */
+        D8 = 56, /* 8 */
+        D9 = 57, /* 9 */
+
+        Semicolon = 59, /* ; */
+        Equal = 61,     /* = */
+
+        A = 65,
+        B = 66,
+        C = 67,
+        D = 68,
+        E = 69,
+        F = 70,
+        G = 71,
+        H = 72,
+        I = 73,
+        J = 74,
+        K = 75,
+        L = 76,
+        M = 77,
+        N = 78,
+        O = 79,
+        P = 80,
+        Q = 81,
+        R = 82,
+        S = 83,
+        T = 84,
+        U = 85,
+        V = 86,
+        W = 87,
+        X = 88,
+        Y = 89,
+        Z = 90,
+
+        LeftBracket = 91,  /* [ */
+        Backslash = 92,    /* \ */
+        RightBracket = 93, /* ] */
+        GraveAccent = 96,  /* ` */
+
+        World1 = 161, /* non-US #1 */
+        World2 = 162, /* non-US #2 */
+
+        /* Function keys */
+        Escape = 256,
+        Enter = 257,
+        Tab = 258,
+        Backspace = 259,
+        Insert = 260,
+        Delete = 261,
+        Right = 262,
+        Left = 263,
+        Down = 264,
+        Up = 265,
+        PageUp = 266,
+        PageDown = 267,
+        Home = 268,
+        End = 269,
+        CapsLock = 280,
+        ScrollLock = 281,
+        NumLock = 282,
+        PrintScreen = 283,
+        Pause = 284,
+        F1 = 290,
+        F2 = 291,
+        F3 = 292,
+        F4 = 293,
+        F5 = 294,
+        F6 = 295,
+        F7 = 296,
+        F8 = 297,
+        F9 = 298,
+        F10 = 299,
+        F11 = 300,
+        F12 = 301,
+        F13 = 302,
+        F14 = 303,
+        F15 = 304,
+        F16 = 305,
+        F17 = 306,
+        F18 = 307,
+        F19 = 308,
+        F20 = 309,
+        F21 = 310,
+        F22 = 311,
+        F23 = 312,
+        F24 = 313,
+        F25 = 314,
+
+        /* Keypad */
+        KP0 = 320,
+        KP1 = 321,
+        KP2 = 322,
+        KP3 = 323,
+        KP4 = 324,
+        KP5 = 325,
+        KP6 = 326,
+        KP7 = 327,
+        KP8 = 328,
+        KP9 = 329,
+        KPDecimal = 330,
+        KPDivide = 331,
+        KPMultiply = 332,
+        KPSubtract = 333,
+        KPAdd = 334,
+        KPEnter = 335,
+        KPEqual = 336,
+
+        LeftShift = 340,
+        LeftControl = 341,
+        LeftAlt = 342,
+        LeftSuper = 343,
+        RightShift = 344,
+        RightControl = 345,
+        RightAlt = 346,
+        RightSuper = 347,
+        Menu = 348
+    } Key;
+} // namespace IC

--- a/include/ic_layer.h
+++ b/include/ic_layer.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "events/ic_event.h"
+
+#include <string>
+#include <vector>
+
+namespace IC {
+    class Layer {
+    public:
+        Layer(const std::string &name = "Layer");
+        virtual ~Layer();
+
+        virtual void OnAttach() {}
+        virtual void OnDetach() {}
+        virtual void OnUpdate() {}
+        virtual void OnEvent(Event &event) {}
+
+        inline const std::string &GetName() const { return _debugName; }
+
+    protected:
+        std::string _debugName;
+    };
+
+    class LayerStack {
+    public:
+        LayerStack();
+        ~LayerStack();
+
+        void PushLayer(Layer *layer);
+        void PushOverlay(Layer *overlay);
+        void PopLayer(Layer *layer);
+        void PopOverlay(Layer *layer);
+
+        std::vector<Layer *>::iterator begin() { return _layers.begin(); };
+        std::vector<Layer *>::iterator end() { return _layers.end(); };
+
+    private:
+        std::vector<Layer *> _layers;
+        std::vector<Layer *>::iterator _layerInsertIndex;
+    };
+} // namespace IC

--- a/include/ic_layer.h
+++ b/include/ic_layer.h
@@ -30,13 +30,13 @@ namespace IC {
         void PushLayer(Layer *layer);
         void PushOverlay(Layer *overlay);
         void PopLayer(Layer *layer);
-        void PopOverlay(Layer *layer);
+        void PopOverlay(Layer *overlay);
 
         std::vector<Layer *>::iterator begin() { return _layers.begin(); };
         std::vector<Layer *>::iterator end() { return _layers.end(); };
 
     private:
         std::vector<Layer *> _layers;
-        std::vector<Layer *>::iterator _layerInsertIndex;
+        int _layerInsertIndex;
     };
 } // namespace IC

--- a/src/ic_app.cpp
+++ b/src/ic_app.cpp
@@ -19,6 +19,9 @@ namespace IC {
 
     void App::Run() {
         while (_isRunning) {
+            for (Layer *layer : _layerStack)
+                layer->OnUpdate();
+
             _window->OnUpdate();
         }
     }
@@ -27,6 +30,23 @@ namespace IC {
         EventDispatcher dispatcher(e);
         dispatcher.Dispatch<WindowCloseEvent>(BIND_EVENT_FN(OnWindowClose));
         dispatcher.Dispatch<WindowResizeEvent>(BIND_EVENT_FN(OnWindowResize));
+
+        // Propagate events up the layer stack and cancel the
+        // event propagation if the event is marked as "handled".
+        for (auto it = _layerStack.end(); it != _layerStack.begin();) {
+            (*--it)->OnEvent(e);
+
+            if (e.handled)
+                break;
+        }
+    }
+
+    void App::PushLayer(Layer *layer) {
+        _layerStack.PushLayer(layer);
+    }
+
+    void App::PushOverlay(Layer *layer) {
+        _layerStack.PushOverlay(layer);
     }
 
     bool App::OnWindowClose(WindowCloseEvent &e) {

--- a/src/ic_app.cpp
+++ b/src/ic_app.cpp
@@ -30,6 +30,7 @@ namespace IC {
         EventDispatcher dispatcher(e);
         dispatcher.Dispatch<WindowCloseEvent>(BIND_EVENT_FN(OnWindowClose));
         dispatcher.Dispatch<WindowResizeEvent>(BIND_EVENT_FN(OnWindowResize));
+        dispatcher.Dispatch<KeyPressedEvent>(BIND_EVENT_FN(OnKeyPressed));
 
         // Propagate events up the layer stack and cancel the
         // event propagation if the event is marked as "handled".
@@ -43,10 +44,26 @@ namespace IC {
 
     void App::PushLayer(Layer *layer) {
         _layerStack.PushLayer(layer);
+        layer->OnAttach();
     }
 
     void App::PushOverlay(Layer *layer) {
         _layerStack.PushOverlay(layer);
+        layer->OnAttach();
+    }
+
+    bool App::OnKeyPressed(KeyPressedEvent &e) {
+        switch (e.GetKeyCode()) {
+        case Key::Escape:
+            _isRunning = false;
+
+            return true;
+            break;
+        default:
+            break;
+        }
+
+        return false;
     }
 
     bool App::OnWindowClose(WindowCloseEvent &e) {

--- a/src/ic_layer.cpp
+++ b/src/ic_layer.cpp
@@ -1,0 +1,41 @@
+#include <ic_layer.h>
+
+namespace IC {
+    Layer::Layer(const std::string &debugName) : _debugName(debugName) {}
+
+    Layer::~Layer() {}
+
+    LayerStack::LayerStack() {
+        _layerInsertIndex = _layers.begin();
+    }
+
+    LayerStack::~LayerStack() {
+        for (Layer *layer : _layers)
+            delete layer;
+    }
+
+    void LayerStack::PushLayer(Layer *layer) {
+        _layerInsertIndex = _layers.emplace(_layerInsertIndex, layer);
+    }
+
+    void LayerStack::PushOverlay(Layer *overlay) {
+        _layers.emplace_back(overlay);
+    }
+
+    void LayerStack::PopLayer(Layer *layer) {
+        auto it = std::find(_layers.begin(), _layers.end(), layer);
+
+        if (it != _layers.end()) {
+            _layers.erase(it);
+            _layerInsertIndex--;
+        }
+    }
+
+    void LayerStack::PopOverlay(Layer *overlay) {
+        auto it = std::find(_layers.begin(), _layers.end(), overlay);
+
+        if (it != _layers.end()) {
+            _layers.erase(it);
+        }
+    }
+} // namespace IC

--- a/src/ic_layer.cpp
+++ b/src/ic_layer.cpp
@@ -6,7 +6,7 @@ namespace IC {
     Layer::~Layer() {}
 
     LayerStack::LayerStack() {
-        _layerInsertIndex = _layers.begin();
+        _layerInsertIndex = 0;
     }
 
     LayerStack::~LayerStack() {
@@ -15,7 +15,8 @@ namespace IC {
     }
 
     void LayerStack::PushLayer(Layer *layer) {
-        _layerInsertIndex = _layers.emplace(_layerInsertIndex, layer);
+        _layers.emplace(_layers.begin() + _layerInsertIndex, layer);
+        _layerInsertIndex++;
     }
 
     void LayerStack::PushOverlay(Layer *overlay) {

--- a/src/platform/glfw_window.cpp
+++ b/src/platform/glfw_window.cpp
@@ -1,7 +1,9 @@
 #include "glfw_window.h"
 
 #include <events/ic_app_event.h>
+#include <events/ic_key_event.h>
 #include <ic_common.h>
+#include <ic_keycodes.h>
 #include <ic_log.h>
 
 #include "ic_renderer.h"
@@ -54,6 +56,28 @@ namespace IC {
 
         _renderer = Renderer::MakeRenderer(RendererConfig(_window, rendererType, props.width, props.height));
         IC_CORE_ASSERT(_renderer != nullptr, "Render module was not found.");
+
+        glfwSetKeyCallback(_window, [](GLFWwindow *window, int key, int scancode, int action, int mods) {
+            WindowData &data = *(WindowData *)glfwGetWindowUserPointer(window);
+
+            switch (action) {
+            case GLFW_PRESS: {
+                KeyPressedEvent event((KeyCode)key, 0);
+                data.eventCallback(event);
+                break;
+            }
+            case GLFW_RELEASE: {
+                KeyReleasedEvent event((KeyCode)key);
+                data.eventCallback(event);
+                break;
+            }
+            case GLFW_REPEAT: {
+                KeyPressedEvent event((KeyCode)key, 1);
+                data.eventCallback(event);
+                break;
+            }
+            }
+        });
 
         glfwSetWindowCloseCallback(_window, [](GLFWwindow *window) {
             WindowData &data = *(WindowData *)glfwGetWindowUserPointer(window);


### PR DESCRIPTION
- Adds the concept of "Layers", which is just really just a glorified list that events can travel through.
  - Use case: You could have your main "game" on one layer, and add a debug layer on top that has its own ImGUI controls that can be completely omitted in release builds.
  - Showcased by adding a `DummyLayer` to the Editor.
  - They're totally optional (but seemed really nice to have).
- Adds Keyboard events.
  - Wires up the app to close the window when pressing Escape, as a demo.
  - :pencil: I noticed that the keycodes between GLFW and SDL are very different. I wonder if there's a specific reason why? Apparently SDL's keycodes are in-line with the [USB standard](https://www.usb.org/sites/default/files/documents/hut1_12v2.pdf). Just wanted to raise awareness of this.
  
Still pretty much on the [Hazel](https://github.com/TheCherno/Hazel) train.